### PR TITLE
fix: Add user messages to UI when sent via TextInput

### DIFF
--- a/web-app/src/components/TextInput/TextInput.tsx
+++ b/web-app/src/components/TextInput/TextInput.tsx
@@ -14,6 +14,8 @@ const MotionIconButton = motion.create(IconButton);
 
 export function TextInput({ isActive, onActivate }: TextInputProps) {
   const send = useStore((state) => state.socket.send);
+  const addMessage = useStore((state) => state.session.addMessage);
+  const activeSessionId = useStore((state) => state.session.activeSessionId);
   const [textMessage, setTextMessage] = useState('');
   const [isSending, setIsSending] = useState(false);
 
@@ -26,6 +28,22 @@ export function TextInput({ isActive, onActivate }: TextInputProps) {
     if (textMessage.trim() && !isSending) {
       setIsSending(true);
       try {
+        // Add user message to local state immediately
+        if (activeSessionId) {
+          const userMessage = {
+            message_id: `user-${Date.now()}`,
+            session_id: activeSessionId,
+            user_id: '',
+            message_source: 'user' as const,
+            message_kind: 'text',
+            message_content: textMessage,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          };
+          addMessage(userMessage);
+        }
+
+        // Send message through WebSocket
         send(textMessage);
         setTextMessage('');
       } finally {


### PR DESCRIPTION
User typed messages were not appearing in the conversation history because they were only sent through WebSocket without being added to the local session state. This fix adds an optimistic update to immediately display user messages in the UI when sent.

Fixes #9

Generated with [Claude Code](https://claude.ai/code)