### PR TITLE
feat: add Render preview environment configuration

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -26,19 +26,16 @@ services:
     previewsExpireAfterDays: 7
 
   # Frontend Web App Service
-  - type: web
+  - type: static
     name: arabic-voice-agent-web-app
-    env: node
     region: oregon
     plan: starter
     buildCommand: npm ci && npm run build
-    startCommand: npm run preview -- --host 0.0.0.0 --port $PORT
+    staticPublishPath: ./dist
     rootDir: web-app
     envVars:
       - key: NODE_VERSION
         value: "20"
-      - key: PORT
-        generateValue: true
       - key: VITE_API_URL
         sync: false
       - key: VITE_SUPABASE_URL


### PR DESCRIPTION
Add render.yaml file that configures preview deployments for both web-api and web-app services. Preview environments will automatically deploy from pull requests and expire after 7 days.

Resolves #11

Generated with [Claude Code](https://claude.ai/code)