### PR TITLE
fix: update render.yaml to use starter plan and remove static site region

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,7 @@ services:
     env: python
     region: oregon
     plan: starter
-    previewPlan: free
+    previewPlan: starter
     buildCommand: pip install uv && uv sync
     startCommand: uv run uvicorn main:app --host 0.0.0.0 --port $PORT
     rootDir: web-api
@@ -31,9 +31,8 @@ services:
   - type: web
     name: arabic-voice-agent-web-app
     runtime: static
-    region: oregon
     plan: starter
-    previewPlan: free
+    previewPlan: starter
     buildCommand: npm ci && npm run build
     staticPublishPath: ./dist
     rootDir: web-app


### PR DESCRIPTION
Fixed render.yaml configuration issues reported in #15:

- Changed previewPlan from "free" to "starter" for both services
- Removed region configuration from static site service (not allowed)

Fixes #15

---
Generated with [Claude Code](https://claude.ai/code)