### PR TITLE
feat(ci): configure arabizi.chat custom domain for prod AWS deployment

### DIFF
--- a/.github/workflows/deploy-bootstrap.yml
+++ b/.github/workflows/deploy-bootstrap.yml
@@ -1,0 +1,41 @@
+name: Deploy Bootstrap (AWS)
+
+on:
+  workflow_dispatch:
+
+env:
+  AWS_REGION: us-west-2
+
+jobs:
+  deploy-bootstrap:
+    name: Deploy bootstrap stack
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get GitHub OIDC provider ARN
+        id: oidc
+        run: |
+          ARN=$(aws iam list-open-id-connect-providers \
+            --query "OpenIDConnectProviderList[?ends_with(Arn, 'token.actions.githubusercontent.com')].Arn" \
+            --output text)
+          echo "arn=$ARN" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy CloudFormation bootstrap stack
+        run: |
+          aws cloudformation deploy \
+            --stack-name arabic-voice-agent-bootstrap \
+            --template-file infra/bootstrap/template.yaml \
+            --capabilities CAPABILITY_NAMED_IAM \
+            --no-fail-on-empty-changeset \
+            --parameter-overrides \
+              GitHubOidcProviderArn="${{ steps.oidc.outputs.arn }}"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -68,6 +68,8 @@ jobs:
       admin_bucket: ${{ steps.outputs.outputs.admin_bucket }}
       web_app_dist_id: ${{ steps.outputs.outputs.web_app_dist_id }}
       admin_dist_id: ${{ steps.outputs.outputs.admin_dist_id }}
+      web_app_cf_domain: ${{ steps.outputs.outputs.web_app_cf_domain }}
+      admin_cf_domain: ${{ steps.outputs.outputs.admin_cf_domain }}
     steps:
       - uses: actions/checkout@v4
 
@@ -106,6 +108,7 @@ jobs:
             --template-file infra/prod/template.yaml \
             --no-fail-on-empty-changeset \
             --parameter-overrides \
+              AcmCertificateArn="${{ secrets.AWS_ACM_CERTIFICATE_ARN }}" \
               EcrImageUri="${{ needs.build-api-image.outputs.image_uri }}" \
               ClaudeAgentEcrImageUri="${{ steps.claude-agent-image.outputs.image_uri }}" \
               AppRunnerEcrRoleArn="${{ secrets.AWS_APP_RUNNER_ECR_ROLE_ARN }}" \
@@ -137,6 +140,44 @@ jobs:
           echo "admin_bucket=$(get_output AdminBucketName)" >> "$GITHUB_OUTPUT"
           echo "web_app_dist_id=$(get_output WebAppDistributionId)" >> "$GITHUB_OUTPUT"
           echo "admin_dist_id=$(get_output AdminDistributionId)" >> "$GITHUB_OUTPUT"
+          echo "web_app_cf_domain=$(get_output WebAppCloudFrontDomain)" >> "$GITHUB_OUTPUT"
+          echo "admin_cf_domain=$(get_output AdminCloudFrontDomain)" >> "$GITHUB_OUTPUT"
+
+      - name: Associate App Runner custom domain
+        run: |
+          API_SERVICE_ARN=$(aws apprunner list-services \
+            --query "ServiceSummaryList[?ServiceName=='prod-api'].ServiceArn" \
+            --output text)
+
+          if [ -z "$API_SERVICE_ARN" ]; then
+            echo "Could not find prod-api service, skipping custom domain association"
+            exit 0
+          fi
+
+          EXISTING=$(aws apprunner describe-custom-domains \
+            --service-arn "$API_SERVICE_ARN" \
+            --query "CustomDomains[?DomainName=='api.arabizi.chat'].DomainName" \
+            --output text 2>/dev/null)
+
+          if [ -z "$EXISTING" ]; then
+            echo "Associating api.arabizi.chat with App Runner..."
+            aws apprunner associate-custom-domain \
+              --service-arn "$API_SERVICE_ARN" \
+              --domain-name "api.arabizi.chat"
+          else
+            echo "api.arabizi.chat is already associated"
+          fi
+
+          # Print DNS records needed for api.arabizi.chat
+          DOMAIN_INFO=$(aws apprunner describe-custom-domains \
+            --service-arn "$API_SERVICE_ARN" \
+            --query "CustomDomains[?DomainName=='api.arabizi.chat']" \
+            --output json 2>/dev/null)
+
+          echo "### api.arabizi.chat DNS records" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          echo "$DOMAIN_INFO" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
   # ------------------------------------------------------------------
   # Job 3: Build static sites and upload to S3
@@ -165,7 +206,7 @@ jobs:
       - name: Build web-app
         working-directory: web-app
         env:
-          VITE_API_URL: ${{ needs.deploy-infra.outputs.api_url }}
+          VITE_API_URL: ${{ vars.API_URL || needs.deploy-infra.outputs.api_url }}
           VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY }}
         run: |
@@ -209,9 +250,17 @@ jobs:
         run: |
           echo "### Production Deployment Complete" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Service | URL |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|---------|-----|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| API | ${{ needs.deploy-infra.outputs.api_url }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Claude Agent | ${{ needs.deploy-infra.outputs.claude_agent_url }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Web App | ${{ needs.deploy-infra.outputs.web_app_url }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Admin | ${{ needs.deploy-infra.outputs.admin_url }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Service | Custom Domain | CloudFront/App Runner URL |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---------|---------------|--------------------------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| API | https://api.arabizi.chat | ${{ needs.deploy-infra.outputs.api_url }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Claude Agent | — | ${{ needs.deploy-infra.outputs.claude_agent_url }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Web App | https://arabizi.chat | https://${{ needs.deploy-infra.outputs.web_app_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Admin | https://admin.arabizi.chat | https://${{ needs.deploy-infra.outputs.admin_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**DNS records required** (set these at your DNS provider):" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Record | Type | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|--------|------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| arabizi.chat | ALIAS/ANAME | ${{ needs.deploy-infra.outputs.web_app_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| www.arabizi.chat | CNAME | ${{ needs.deploy-infra.outputs.web_app_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| admin.arabizi.chat | CNAME | ${{ needs.deploy-infra.outputs.admin_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| api.arabizi.chat | CNAME | (see App Runner DNS records section above) |" >> "$GITHUB_STEP_SUMMARY"

--- a/infra/bootstrap/template.yaml
+++ b/infra/bootstrap/template.yaml
@@ -113,7 +113,7 @@ Resources:
                   - !GetAtt EcrRepository.Arn
                   - !GetAtt ClaudeAgentEcrRepository.Arn
 
-              # App Runner - manage preview services
+              # App Runner - manage preview services and custom domains
               - Sid: AppRunner
                 Effect: Allow
                 Action:
@@ -128,6 +128,9 @@ Resources:
                   - apprunner:CreateAutoScalingConfiguration
                   - apprunner:DeleteAutoScalingConfiguration
                   - apprunner:DescribeAutoScalingConfiguration
+                  - apprunner:AssociateCustomDomain
+                  - apprunner:DisassociateCustomDomain
+                  - apprunner:DescribeCustomDomains
                 Resource: "*"
 
               # S3 - manage preview and production static site buckets

--- a/infra/prod/template.yaml
+++ b/infra/prod/template.yaml
@@ -4,6 +4,14 @@ Description: >
   Creates App Runner (API, Claude agent), S3 + CloudFront (web-app, admin-app).
 
 Parameters:
+  AcmCertificateArn:
+    Type: String
+    Default: ""
+    Description: >
+      ARN of an ACM certificate in us-east-1 covering arabizi.chat and *.arabizi.chat.
+      Required for custom domain aliases on CloudFront distributions.
+      Leave empty to use the default CloudFront certificate (no custom domain).
+
   EcrImageUri:
     Type: String
     Description: "Full ECR image URI for web-api"
@@ -67,6 +75,9 @@ Parameters:
     Type: String
     NoEcho: true
     Description: GitHub webhook secret for Claude agent
+
+Conditions:
+  HasCustomDomain: !Not [!Equals [!Ref AcmCertificateArn, ""]]
 
 Resources:
   # ============================================================
@@ -228,6 +239,16 @@ Resources:
         Comment: Production - web-app
         DefaultRootObject: index.html
         PriceClass: PriceClass_100
+        Aliases: !If
+          - HasCustomDomain
+          - [arabizi.chat, www.arabizi.chat]
+          - !Ref AWS::NoValue
+        ViewerCertificate: !If
+          - HasCustomDomain
+          - AcmCertificateArn: !Ref AcmCertificateArn
+            SslSupportMethod: sni-only
+            MinimumProtocolVersion: TLSv1.2_2021
+          - CloudFrontDefaultCertificate: true
         Origins:
           - Id: S3Origin
             DomainName: !GetAtt WebAppBucket.RegionalDomainName
@@ -307,6 +328,16 @@ Resources:
         Comment: Production - admin
         DefaultRootObject: index.html
         PriceClass: PriceClass_100
+        Aliases: !If
+          - HasCustomDomain
+          - [admin.arabizi.chat]
+          - !Ref AWS::NoValue
+        ViewerCertificate: !If
+          - HasCustomDomain
+          - AcmCertificateArn: !Ref AcmCertificateArn
+            SslSupportMethod: sni-only
+            MinimumProtocolVersion: TLSv1.2_2021
+          - CloudFrontDefaultCertificate: true
         Origins:
           - Id: S3Origin
             DomainName: !GetAtt AdminBucket.RegionalDomainName
@@ -363,3 +394,13 @@ Outputs:
   AdminBucketName:
     Description: Admin S3 bucket name
     Value: !Ref AdminBucket
+
+  WebAppCloudFrontDomain:
+    Description: >
+      Web app CloudFront domain (point arabizi.chat and www.arabizi.chat here via ALIAS/CNAME)
+    Value: !GetAtt WebAppDistribution.DomainName
+
+  AdminCloudFrontDomain:
+    Description: >
+      Admin CloudFront domain (point admin.arabizi.chat here via CNAME)
+    Value: !GetAtt AdminDistribution.DomainName


### PR DESCRIPTION
- Add ACM certificate support to CloudFront distributions (web-app and admin) with conditional aliases: mishmish.ai/www for web-app, admin.mishmish.ai for admin
- Add deploy-bootstrap.yml workflow for redeploying bootstrap stack from GitHub
- Associate api.mishmish.ai as App Runner custom domain in deploy-prod.yml
- Use vars.API_URL with App Runner URL fallback for VITE_API_URL build arg
- Output CloudFront domain names in job summary with DNS setup instructions
- Add apprunner:AssociateCustomDomain/DisassociateCustomDomain/DescribeCustomDomains permissions to GitHub Actions IAM role in bootstrap stack