### PR TITLE
feat(config): auto-setup worktrees with env, ports, and dependencies

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/worktree-setup-hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/admin-app/.env.example
+++ b/admin-app/.env.example
@@ -1,3 +1,6 @@
+# Vite dev server port (set automatically per worktree — do not edit manually)
+PORT=5174
+
 VITE_SUPABASE_URL=http://127.0.0.1:54321
 VITE_SUPABASE_ANON_KEY=your-anon-key
 VITE_API_URL=http://localhost:8000

--- a/admin-app/vite.config.ts
+++ b/admin-app/vite.config.ts
@@ -1,17 +1,20 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
-  server: {
-    port: 5174,
-    allowedHosts: ['localhost', '.claude.ai'],
-  },
+    server: {
+      port: parseInt(env.PORT || '5174'),
+      allowedHosts: ['localhost', '.claude.ai'],
+    },
+  }
 })

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Sets up a newly created git worktree:
+#   1. Pulls latest changes from the remote default branch
+#   2. Copies .env files from the main worktree
+#   3. Patches ports to be unique (derived from worktree name)
+#   4. Installs dependencies (uv sync, npm install)
+#
+# Usage: setup-worktree.sh <worktree-path>
+#
+# Port allocation (deterministic, based on worktree name hash, slot 1-20):
+#   web-api  : 8000 + slot*10   (8010–8200)  — also used for WEBHOOK_BASE_URL
+#   web-app  : 5200 + slot       (5201–5220)  — Vite dev server
+#   admin-app: 5220 + slot       (5221–5240)  — Vite dev server
+#   debugpy  : 5670 + slot       (5671–5690)  — Python remote debugger
+
+set -euo pipefail
+
+WORKTREE_PATH="${1:?Usage: $0 <worktree-path>}"
+
+# Resolve to absolute path
+if [[ "$WORKTREE_PATH" != /* ]]; then
+    WORKTREE_PATH="$(pwd)/$WORKTREE_PATH"
+fi
+
+if [ ! -d "$WORKTREE_PATH" ]; then
+    echo "Error: worktree path does not exist: $WORKTREE_PATH" >&2
+    exit 1
+fi
+
+# Main worktree is always the first entry in the worktree list
+MAIN_ROOT=$(git -C "$WORKTREE_PATH" worktree list --porcelain | head -1 | sed 's/^worktree //')
+
+WORKTREE_NAME=$(basename "$WORKTREE_PATH")
+
+# Compute deterministic slot 1-20 from worktree name
+SLOT=$(python3 -c "
+import hashlib, sys
+name = sys.argv[1]
+h = int(hashlib.md5(name.encode()).hexdigest(), 16)
+print(h % 20 + 1)
+" "$WORKTREE_NAME")
+
+API_PORT=$((8000 + SLOT * 10))
+WEB_PORT=$((5200 + SLOT))
+ADMIN_PORT=$((5220 + SLOT))
+DEBUGPY_PORT=$((5670 + SLOT))
+
+echo "Setting up worktree: $WORKTREE_NAME (slot $SLOT)"
+echo "  web-api  → http://localhost:$API_PORT"
+echo "  web-app  → http://localhost:$WEB_PORT"
+echo "  admin    → http://localhost:$ADMIN_PORT"
+
+# ---------------------------------------------------------------------------
+# Pull latest from the remote default branch
+# ---------------------------------------------------------------------------
+
+echo "Pulling latest changes..."
+DEFAULT_BRANCH=$(git -C "$MAIN_ROOT" remote show origin 2>/dev/null \
+    | grep 'HEAD branch' | awk '{print $NF}')
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+
+if git -C "$WORKTREE_PATH" fetch origin 2>&1; then
+    git -C "$WORKTREE_PATH" rebase "origin/$DEFAULT_BRANCH" 2>&1 \
+        || echo "  warning: rebase against origin/$DEFAULT_BRANCH had conflicts — resolve manually"
+else
+    echo "  warning: git fetch failed (offline?) — skipping pull"
+fi
+
+# ---------------------------------------------------------------------------
+# Patch .claude/launch.json with worktree-specific ports
+# ---------------------------------------------------------------------------
+
+LAUNCH_JSON="$WORKTREE_PATH/.claude/launch.json"
+if [ -f "$LAUNCH_JSON" ]; then
+    echo "Patching .claude/launch.json..."
+    python3 - "$LAUNCH_JSON" "$API_PORT" "$WEB_PORT" "$ADMIN_PORT" <<'PYEOF'
+import json, sys
+
+path, api_port, web_port, admin_port = sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4])
+
+port_map = {'web-app': web_port, 'admin-app': admin_port, 'web-api': api_port}
+
+with open(path) as f:
+    config = json.load(f)
+
+for conf in config.get('configurations', []):
+    name = conf.get('name')
+    if name not in port_map:
+        continue
+    conf['port'] = port_map[name]
+    # Patch --port <value> in runtimeArgs (e.g. uvicorn --port 8000)
+    args = conf.get('runtimeArgs', [])
+    for i, arg in enumerate(args):
+        if arg == '--port' and i + 1 < len(args):
+            args[i + 1] = str(port_map[name])
+
+with open(path, 'w') as f:
+    json.dump(config, f, indent=2)
+    f.write('\n')
+PYEOF
+fi
+
+# ---------------------------------------------------------------------------
+# Copy .env files from the main worktree (fall back to .env.example)
+# ---------------------------------------------------------------------------
+
+copy_env() {
+    local relative_path="$1"
+    local src="$MAIN_ROOT/$relative_path"
+    local dest="$WORKTREE_PATH/$relative_path"
+    local dest_dir
+    dest_dir="$(dirname "$dest")"
+
+    mkdir -p "$dest_dir"
+
+    if [ -f "$src" ]; then
+        cp "$src" "$dest"
+        echo "  copied $relative_path"
+    elif [ -f "${src}.example" ]; then
+        cp "${src}.example" "$dest"
+        echo "  copied $relative_path (from .example)"
+    else
+        echo "  skipped $relative_path (not found)"
+    fi
+}
+
+echo "Copying .env files..."
+copy_env ".env"
+copy_env "web-api/.env"
+copy_env "web-app/.env"
+copy_env "admin-app/.env"
+
+# ---------------------------------------------------------------------------
+# Patch ports in the copied .env files
+# ---------------------------------------------------------------------------
+
+patch_env() {
+    local file="$1"
+    [ -f "$file" ] || return 0
+    shift
+    for expr in "$@"; do
+        perl -i -pe "$expr" "$file"
+    done
+}
+
+echo "Patching ports..."
+
+# web-api: PORT and WEBHOOK_BASE_URL
+patch_env "$WORKTREE_PATH/web-api/.env" \
+    "s|^PORT=.*|PORT=$API_PORT|" \
+    "s|WEBHOOK_BASE_URL=http://localhost:[0-9]*|WEBHOOK_BASE_URL=http://localhost:$API_PORT|"
+
+# Add/update DEBUGPY_PORT in web-api/.env
+if [ -f "$WORKTREE_PATH/web-api/.env" ]; then
+    if grep -q "^DEBUGPY_PORT=" "$WORKTREE_PATH/web-api/.env"; then
+        perl -i -pe "s|^DEBUGPY_PORT=.*|DEBUGPY_PORT=$DEBUGPY_PORT|" "$WORKTREE_PATH/web-api/.env"
+    else
+        echo "DEBUGPY_PORT=$DEBUGPY_PORT" >> "$WORKTREE_PATH/web-api/.env"
+    fi
+fi
+
+# web-app: VITE_API_URL and PORT (Vite dev server)
+patch_env "$WORKTREE_PATH/web-app/.env" \
+    "s|VITE_API_URL=http://localhost:[0-9]*|VITE_API_URL=http://localhost:$API_PORT|" \
+    "s|^PORT=.*|PORT=$WEB_PORT|"
+
+# admin-app: VITE_API_URL and PORT (Vite dev server)
+patch_env "$WORKTREE_PATH/admin-app/.env" \
+    "s|VITE_API_URL=http://localhost:[0-9]*|VITE_API_URL=http://localhost:$API_PORT|" \
+    "s|^PORT=.*|PORT=$ADMIN_PORT|"
+
+# ---------------------------------------------------------------------------
+# Install dependencies (parallel)
+# ---------------------------------------------------------------------------
+
+echo "Installing dependencies..."
+
+(
+    cd "$WORKTREE_PATH/web-api"
+    uv sync --quiet && echo "  web-api deps installed"
+) &
+PID_API=$!
+
+(
+    cd "$WORKTREE_PATH/web-app"
+    npm install --silent && echo "  web-app deps installed"
+) &
+PID_WEB=$!
+
+(
+    cd "$WORKTREE_PATH/admin-app"
+    npm install --silent && echo "  admin-app deps installed"
+) &
+PID_ADMIN=$!
+
+wait $PID_API || echo "  web-api: dependency install failed (check manually)"
+wait $PID_WEB || echo "  web-app: dependency install failed (check manually)"
+wait $PID_ADMIN || echo "  admin-app: dependency install failed (check manually)"
+
+echo ""
+echo "Worktree $WORKTREE_NAME ready."
+echo "  API:      http://localhost:$API_PORT"
+echo "  web-app:  http://localhost:$WEB_PORT"
+echo "  admin:    http://localhost:$ADMIN_PORT"

--- a/scripts/worktree-setup-hook.sh
+++ b/scripts/worktree-setup-hook.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# PostToolUse hook for Bash — triggers worktree setup after "git worktree add"
+# Receives JSON on stdin from Claude Code.
+
+INPUT=$(cat)
+
+# Cheap pre-check before invoking python3
+if ! echo "$INPUT" | grep -q 'git worktree add'; then
+    exit 0
+fi
+
+COMMAND=$(echo "$INPUT" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_input', {}).get('command', ''))
+except Exception:
+    print('')
+")
+
+if ! echo "$COMMAND" | grep -qE 'git worktree add'; then
+    exit 0
+fi
+
+# Extract the worktree path from the command using proper shell tokenisation.
+# git worktree add [-f] [--detach] [--lock] [-b <branch>] [-B <branch>]
+#                  [--reason <string>] [--orphan] <path> [<commit-ish>]
+# Flags that consume a following argument:
+WORKTREE_PATH=$(echo "$COMMAND" | python3 -c "
+import sys, shlex
+
+try:
+    parts = shlex.split(sys.stdin.read().strip())
+except ValueError:
+    sys.exit(0)
+
+# Flags that consume the next token as their argument
+consumes_arg = {'-b', '-B', '--reason'}
+
+try:
+    wt_idx = parts.index('worktree')
+    # parts[wt_idx+1] == 'add'
+    i = wt_idx + 2
+except (ValueError, IndexError):
+    sys.exit(0)
+
+while i < len(parts):
+    token = parts[i]
+    if token == '--':          # end of flags
+        i += 1
+        break
+    if token in consumes_arg:  # flag + argument, skip both
+        i += 2
+    elif token.startswith('-'): # bare flag, skip
+        i += 1
+    else:
+        print(token)           # first positional arg = path
+        sys.exit(0)
+    i += 1
+")
+
+if [ -z "$WORKTREE_PATH" ]; then
+    exit 0
+fi
+
+# Make absolute if relative (hook runs from the repo root)
+if [[ "$WORKTREE_PATH" != /* ]]; then
+    WORKTREE_PATH="$(pwd)/$WORKTREE_PATH"
+fi
+
+if [ ! -d "$WORKTREE_PATH" ]; then
+    # git worktree add may have failed — nothing to set up
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$SCRIPT_DIR/setup-worktree.sh" "$WORKTREE_PATH" 2>&1 | sed 's/^/[worktree-setup] /'
+
+exit 0

--- a/web-app/.env.example
+++ b/web-app/.env.example
@@ -1,3 +1,6 @@
+# Vite dev server port (set automatically per worktree — do not edit manually)
+PORT=5173
+
 # API URL for LiveKit token generation (base URL only, not the full endpoint)
 # The code will append /livekit/token automatically
 # For local development, this should point to your local web-api server

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -1,17 +1,20 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
-  server: {
-    port: 5173,
-    allowedHosts: ['localhost', '.claude.ai'],
-  },
+    server: {
+      port: parseInt(env.PORT || '5173'),
+      allowedHosts: ['localhost', '.claude.ai'],
+    },
+  }
 })


### PR DESCRIPTION
Adds a Claude Code PostToolUse hook that fires whenever a git worktree is created. The hook runs a setup script that:

- Pulls latest changes from the remote default branch (fetch + rebase)
- Copies .env files from the main worktree (falls back to .env.example)
- Assigns unique, deterministic ports per worktree (derived from an MD5 hash of the worktree name) and patches them into all .env files and .claude/launch.json so the Claude Code preview button targets the right port
- Installs dependencies in parallel (uv sync, npm install)

Port ranges (slot 1–20, never collides with main-branch defaults):
  web-api:   8010–8200  |  web-app: 5201–5220  |  admin: 5221–5240

Also updates web-app and admin-app vite.config.ts to read the dev-server port from the PORT env var (falls back to 5173/5174), enabling each worktree to serve on its own port without config changes.