### PR TITLE
ci: add claude.mishmish.ai custom domain for Claude agent

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -143,44 +143,49 @@ jobs:
           echo "web_app_cf_domain=$(get_output WebAppCloudFrontDomain)" >> "$GITHUB_OUTPUT"
           echo "admin_cf_domain=$(get_output AdminCloudFrontDomain)" >> "$GITHUB_OUTPUT"
 
-      - name: Associate App Runner custom domain
+      - name: Associate App Runner custom domains
         run: |
-          API_SERVICE_ARN=$(aws apprunner list-services \
-            --query "ServiceSummaryList[?ServiceName=='prod-api'].ServiceArn" \
-            --output text)
+          associate_domain() {
+            local SERVICE_NAME="$1"
+            local DOMAIN="$2"
 
-          if [ -z "$API_SERVICE_ARN" ]; then
-            echo "Could not find prod-api service, skipping custom domain association"
-            exit 0
-          fi
+            SERVICE_ARN=$(aws apprunner list-services \
+              --query "ServiceSummaryList[?ServiceName=='$SERVICE_NAME'].ServiceArn" \
+              --output text)
 
-          # Check all domains (any status) to detect pending associations from prior runs
-          EXISTING=$(aws apprunner describe-custom-domains \
-            --service-arn "$API_SERVICE_ARN" \
-            --output json 2>/dev/null \
-            | grep -o '"api\.mishmish\.ai"' || true)
+            if [ -z "$SERVICE_ARN" ]; then
+              echo "Could not find $SERVICE_NAME service, skipping $DOMAIN association"
+              return 0
+            fi
 
-          if [ -z "$EXISTING" ]; then
-            echo "Associating api.mishmish.ai with App Runner..."
-            # Non-fatal: domain may already be in progress from a prior run
-            aws apprunner associate-custom-domain \
-              --service-arn "$API_SERVICE_ARN" \
-              --domain-name "api.mishmish.ai" \
-              || echo "Warning: domain association returned an error (may already be pending — check App Runner console)"
-          else
-            echo "api.mishmish.ai is already associated"
-          fi
+            EXISTING=$(aws apprunner describe-custom-domains \
+              --service-arn "$SERVICE_ARN" \
+              --output json 2>/dev/null \
+              | grep -o "\"$DOMAIN\"" || true)
 
-          # Print DNS records needed for api.mishmish.ai
-          DOMAIN_INFO=$(aws apprunner describe-custom-domains \
-            --service-arn "$API_SERVICE_ARN" \
-            --query "CustomDomains[?DomainName=='api.mishmish.ai']" \
-            --output json 2>/dev/null || echo "[]")
+            if [ -z "$EXISTING" ]; then
+              echo "Associating $DOMAIN with $SERVICE_NAME..."
+              aws apprunner associate-custom-domain \
+                --service-arn "$SERVICE_ARN" \
+                --domain-name "$DOMAIN" \
+                || echo "Warning: domain association returned an error (may already be pending — check App Runner console)"
+            else
+              echo "$DOMAIN is already associated"
+            fi
 
-          echo "### api.mishmish.ai DNS records" >> "$GITHUB_STEP_SUMMARY"
-          echo '```json' >> "$GITHUB_STEP_SUMMARY"
-          echo "$DOMAIN_INFO" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+            DOMAIN_INFO=$(aws apprunner describe-custom-domains \
+              --service-arn "$SERVICE_ARN" \
+              --query "CustomDomains[?DomainName=='$DOMAIN']" \
+              --output json 2>/dev/null || echo "[]")
+
+            echo "### $DOMAIN DNS records" >> "$GITHUB_STEP_SUMMARY"
+            echo '```json' >> "$GITHUB_STEP_SUMMARY"
+            echo "$DOMAIN_INFO" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          associate_domain "prod-api" "api.mishmish.ai"
+          associate_domain "prod-claude-agent" "claude.mishmish.ai"
 
   # ------------------------------------------------------------------
   # Job 3: Build static sites and upload to S3
@@ -256,7 +261,7 @@ jobs:
           echo "| Service | Custom Domain | CloudFront/App Runner URL |" >> "$GITHUB_STEP_SUMMARY"
           echo "|---------|---------------|--------------------------|" >> "$GITHUB_STEP_SUMMARY"
           echo "| API | https://api.mishmish.ai | ${{ needs.deploy-infra.outputs.api_url }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Claude Agent | — | ${{ needs.deploy-infra.outputs.claude_agent_url }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Claude Agent | https://claude.mishmish.ai | ${{ needs.deploy-infra.outputs.claude_agent_url }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Web App | https://mishmish.ai | https://${{ needs.deploy-infra.outputs.web_app_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Admin | https://admin.mishmish.ai | https://${{ needs.deploy-infra.outputs.admin_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -267,3 +272,4 @@ jobs:
           echo "| www.mishmish.ai | CNAME | ${{ needs.deploy-infra.outputs.web_app_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| admin.mishmish.ai | CNAME | ${{ needs.deploy-infra.outputs.admin_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| api.mishmish.ai | CNAME | (see App Runner DNS records section above) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| claude.mishmish.ai | CNAME | (see App Runner DNS records section above) |" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Associates `claude.mishmish.ai` with the `prod-claude-agent` App Runner service during production deploy
- Refactors the single-use domain association step into a reusable `associate_domain` shell function (used for both `api.mishmish.ai` and `claude.mishmish.ai`)
- Updates deployment summary table and DNS records section to include `claude.mishmish.ai`

## After merging
Add a CNAME DNS record at your DNS provider using the value shown in the GitHub Actions step summary after the workflow runs:
```
claude.mishmish.ai  →  CNAME  →  <App Runner DNS target from step summary>
```
You'll also need to add the TXT verification record that App Runner provides.

## Test plan
- [ ] Merge and let deploy-prod workflow run
- [ ] Check GitHub Actions step summary for `claude.mishmish.ai` DNS records
- [ ] Add CNAME + TXT records at DNS provider
- [ ] Confirm `https://claude.mishmish.ai` resolves to the Claude agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)