### PR TITLE
docs: revamp README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,103 @@
-# mishmish.ai
+<div align="center">
 
-A multilingual voice and text chat application for Arabic language learning, supporting Modern Standard Arabic, Iraqi, and Egyptian dialects with seamless English code-switching.
+# 🍑 mishmish.ai
 
-## 🏗️ Architecture
+**Talk Arabic. Like a local.**
 
-- **Web App**: React + Vite marketing website with voice demo
-- **Mobile Apps**: Flutter (iOS + Android)
-- **Web API**: FastAPI with Pipecat for real-time voice pipelines
-- **Voice Pipeline**: Pipecat framework orchestrating STT → LLM → TTS
-- **LLM**: OpenAI GPT-4o
-- **Text-to-Speech**: ElevenLabs (Multilingual v2)
-- **Speech-to-Text**: Deepgram (real-time) / Soniox (async with webhooks)
-- **Auth & Database**: Supabase (PostgreSQL + Google OAuth)
+A real-time voice and chat app for Arabic learners — supporting Modern Standard Arabic, Iraqi, and Egyptian dialects with natural English code-switching.
 
-## 📁 Monorepo Structure
+[Live App](https://mishmish.ai) · [Setup Guide](docs/SETUP.md) · [Deployment](docs/DEPLOYMENT.md)
+
+---
+
+</div>
+
+## What it does
+
+mishmish.ai lets you have real, spoken conversations in Arabic. Pick a dialect, start talking, and get intelligent responses back — all in under a second. Built for learners who want to go beyond textbook Arabic.
+
+- **Real-time voice** — speak and hear responses with < 1s latency
+- **Dialect-aware** — switch between MSA, Iraqi, and Egyptian mid-conversation
+- **Code-switching** — mix English and Arabic naturally, just like real speakers do
+- **Web + Mobile** — React web app and Flutter iOS/Android app
+
+---
+
+## Stack
+
+| Layer | Tech |
+|---|---|
+| Voice pipeline | [Pipecat](https://github.com/pipecat-ai/pipecat) — STT → LLM → TTS |
+| Speech-to-text | Deepgram (real-time) |
+| LLM | OpenAI GPT-4o |
+| Text-to-speech | ElevenLabs Multilingual v2 |
+| Backend | FastAPI (Python, uv) |
+| Web frontend | React 19 + Vite + TypeScript |
+| Mobile | Flutter (iOS + Android) |
+| Auth & DB | Supabase (PostgreSQL + Google OAuth) |
+
+---
+
+## Monorepo layout
 
 ```
-arabic-voice-agent/
-├── web-app/             # Marketing website (React + Vite)
-├── flutter-app/         # Flutter app (iOS + Android)
-├── web-api/             # FastAPI backend for voice and chat
-├── docs/                # Documentation
-└── .github/             # CI/CD workflows
+mishmish.ai/
+├── web-app/        # Marketing site + voice demo (React + Vite)
+├── web-api/        # FastAPI backend + Pipecat voice pipelines
+├── flutter-app/    # Mobile app (iOS + Android)
+├── admin-app/      # Internal admin dashboard
+├── supabase/       # DB migrations and config
+├── infra/          # AWS App Runner + CDK infra
+└── docs/           # Architecture, setup, deployment guides
 ```
 
-## 🚀 Quick Start
+---
 
-See [docs/SETUP.md](docs/SETUP.md) for detailed setup instructions.
+## Quick start
 
-### Prerequisites
+**Prerequisites:** Python 3.10+, Node 18+, Flutter 3.24+, Docker (for local Supabase)
 
-- Python 3.10+
-- Flutter 3.24+
-- Node.js 18+
-- Supabase account
-- API keys: OpenAI, ElevenLabs, Deepgram (for pipecat endpoints), Soniox (optional, for legacy endpoints)
-
-### Environment Setup
-
-1. Copy `.env.example` to `.env` in the `web-api` directory and fill in your API keys
-2. Follow the setup instructions in [docs/SETUP.md](docs/SETUP.md)
-
-### Running Locally
-
-**Web API:**
 ```bash
-cd web-api
-# Follow web-api README for setup
+# 1. Clone and set up environment
+cp web-api/.env.example web-api/.env   # add your API keys
+
+# 2. Start Supabase locally
+supabase start
+
+# 3. Start the API
+cd web-api && task dev
+
+# 4. Start the web app
+cd web-app && npm install && npm run dev
 ```
 
-**Web App:**
-```bash
-cd web-app
-npm install
-npm run dev
-```
+You'll need API keys for: **OpenAI**, **ElevenLabs**, **Deepgram**, and **Supabase**.
 
-**Mobile App:**
-```bash
-cd flutter-app
-flutter pub get
-flutter run
-```
+Full setup → [docs/SETUP.md](docs/SETUP.md)
 
-## 🌍 Supported Arabic Dialects
+---
 
-- Modern Standard Arabic (MSA)
-- Iraqi Arabic
-- Egyptian Arabic
-- Mixed English/Arabic
+## Supported dialects
 
-## 📚 Documentation
+| Dialect | Code |
+|---|---|
+| Modern Standard Arabic | `msa` |
+| Iraqi Arabic | `iraqi` |
+| Egyptian Arabic | `egyptian` |
+| Mixed Arabic/English | `mixed` |
+
+---
+
+## Docs
 
 - [Setup Guide](docs/SETUP.md)
-- [Deployment Guide](docs/DEPLOYMENT.md)
 - [Architecture Overview](docs/ARCHITECTURE.md)
+- [Deployment Guide](docs/DEPLOYMENT.md)
 
-## 🔐 Security
+---
 
-- Row-level security (RLS) enabled on all Supabase tables
-- API keys stored as environment variables
-- Google OAuth for authentication
+<div align="center">
 
-## 📄 License
+MIT License · Built with 🍑
 
-MIT
+</div>


### PR DESCRIPTION
## Summary

- Rewrites README with a cleaner layout and better hierarchy
- Adds centered header with tagline and nav links
- Replaces bullet-list architecture with a scannable stack table
- Updates monorepo layout to reflect actual current structure (admin-app, supabase, infra)
- Replaces vague "see sub-README" quick start with actual runnable commands
- Adds dialect table with codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)