### PR TITLE
feat(config): store claude agent secrets in AWS Secrets Manager

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -118,9 +118,7 @@ jobs:
               OpenaiApiKey="${{ secrets.OPENAI_API_KEY }}" \
               SonioxApiKey="${{ secrets.SONIOX_API_KEY }}" \
               ElevenApiKey="${{ secrets.ELEVEN_API_KEY }}" \
-              AnthropicApiKey="${{ secrets.ANTHROPIC_API_KEY }}" \
-              GitHubToken="${{ secrets.CLAUDE_AGENT_GITHUB_TOKEN }}" \
-              GitHubWebhookSecret="${{ secrets.WEBHOOK_SECRET }}"
+              ClaudeAgentSecretArn="${{ secrets.CLAUDE_AGENT_SECRET_ARN }}"
 
       - name: Get stack outputs
         id: outputs

--- a/infra/prod/template.yaml
+++ b/infra/prod/template.yaml
@@ -56,25 +56,17 @@ Parameters:
     Description: ElevenLabs API key
 
   # --- Claude agent keys ---
-  AnthropicApiKey:
+  ClaudeAgentSecretArn:
     Type: String
-    NoEcho: true
-    Description: Anthropic API key for Claude agent
-
-  GitHubToken:
-    Type: String
-    NoEcho: true
-    Description: GitHub token for Claude agent
+    Description: >
+      ARN of the AWS Secrets Manager secret containing Claude agent secrets
+      (mishmish/prod/claude). Expected keys: ANTHROPIC_API_KEY, GITHUB_TOKEN,
+      GITHUB_WEBHOOK_SECRET.
 
   GitHubRepo:
     Type: String
     Default: tanyagray/arabic-voice-agent
-    Description: GitHub repository for Claude agent
-
-  GitHubWebhookSecret:
-    Type: String
-    NoEcho: true
-    Description: GitHub webhook secret for Claude agent
+    Description: GitHub repository for Claude agent (not a secret)
 
 Conditions:
   HasCustomDomain: !Not [!Equals [!Ref AcmCertificateArn, ""]]
@@ -139,6 +131,30 @@ Resources:
   # Claude Agent (App Runner)
   # ============================================================
 
+  # IAM role assumed by running agent containers — grants access to agent
+  # secrets only (not API secrets).
+  ClaudeAgentInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: prod-claude-agent-instance-role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: tasks.apprunner.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AgentSecretsAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                  - secretsmanager:DescribeSecret
+                Resource: !Ref ClaudeAgentSecretArn
+
   ClaudeAgentAutoScalingConfig:
     Type: AWS::AppRunner::AutoScalingConfiguration
     Properties:
@@ -161,17 +177,19 @@ Resources:
           ImageConfiguration:
             Port: "8080"
             RuntimeEnvironmentVariables:
-              - Name: ANTHROPIC_API_KEY
-                Value: !Ref AnthropicApiKey
-              - Name: GITHUB_TOKEN
-                Value: !Ref GitHubToken
               - Name: GITHUB_REPO
                 Value: !Ref GitHubRepo
+            RuntimeEnvironmentSecrets:
+              - Name: ANTHROPIC_API_KEY
+                Value: !Sub "${ClaudeAgentSecretArn}:ANTHROPIC_API_KEY::"
+              - Name: GITHUB_TOKEN
+                Value: !Sub "${ClaudeAgentSecretArn}:GITHUB_TOKEN::"
               - Name: GITHUB_WEBHOOK_SECRET
-                Value: !Ref GitHubWebhookSecret
+                Value: !Sub "${ClaudeAgentSecretArn}:GITHUB_WEBHOOK_SECRET::"
       InstanceConfiguration:
         Cpu: "256"
         Memory: "512"
+        InstanceRoleArn: !GetAtt ClaudeAgentInstanceRole.Arn
       AutoScalingConfigurationArn: !GetAtt ClaudeAgentAutoScalingConfig.AutoScalingConfigurationArn
       HealthCheckConfiguration:
         Protocol: HTTP


### PR DESCRIPTION
## Summary
- Replaces raw `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `GITHUB_WEBHOOK_SECRET` CloudFormation parameters with a single `ClaudeAgentSecretArn` referencing `mishmish/prod/claude` in AWS Secrets Manager
- Adds a dedicated IAM instance role (`prod-claude-agent-instance-role`) scoped exclusively to that secret — agent cannot access API secrets and vice versa
- App Runner fetches secrets at startup via `RuntimeEnvironmentSecrets`; no code changes needed in the agent itself

## Pre-merge checklist
- [x] Secret created in AWS Secrets Manager (`mishmish/prod/claude`)
- [x] `CLAUDE_AGENT_SECRET_ARN` added to GitHub `dev` environment secrets
- [x] Old secrets (`ANTHROPIC_API_KEY`, `CLAUDE_AGENT_GITHUB_TOKEN`, `WEBHOOK_SECRET`) removed from GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)