### PR TITLE
feat(config): trigger App Runner redeploy after ECR image sync

### DIFF
--- a/.github/workflows/sync-claude-agent.yml
+++ b/.github/workflows/sync-claude-agent.yml
@@ -63,3 +63,17 @@ jobs:
           echo "- Source: \`$GHCR_IMAGE\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Destination: \`$ECR_LATEST\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Tag: \`$TIMESTAMP\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Trigger App Runner redeployment
+        run: |
+          SERVICE_ARN=$(aws apprunner list-services \
+            --query "ServiceSummaryList[?ServiceName=='prod-claude-agent'].ServiceArn" \
+            --output text)
+
+          if [ -z "$SERVICE_ARN" ]; then
+            echo "Warning: prod-claude-agent App Runner service not found, skipping redeploy trigger"
+            exit 0
+          fi
+
+          aws apprunner start-deployment --service-arn "$SERVICE_ARN"
+          echo "- Redeployment triggered: \`$SERVICE_ARN\`" >> "$GITHUB_STEP_SUMMARY"

--- a/infra/bootstrap/template.yaml
+++ b/infra/bootstrap/template.yaml
@@ -128,6 +128,7 @@ Resources:
                   - apprunner:CreateAutoScalingConfiguration
                   - apprunner:DeleteAutoScalingConfiguration
                   - apprunner:DescribeAutoScalingConfiguration
+                  - apprunner:StartDeployment
                   - apprunner:AssociateCustomDomain
                   - apprunner:DisassociateCustomDomain
                   - apprunner:DescribeCustomDomains


### PR DESCRIPTION
## Summary
- Adds `apprunner:StartDeployment` to the GitHub Actions IAM role in the bootstrap stack
- Adds an explicit `aws apprunner start-deployment` step to `sync-claude-agent.yml` so the App Runner service redeploys immediately after the new image is pushed to ECR, rather than waiting for the auto-deploy polling interval

## Test plan
- [ ] Merge to main
- [ ] Run "Sync Claude Agent Image" workflow manually (`workflow_dispatch`)
- [ ] Verify the "Trigger App Runner redeployment" step completes successfully in the workflow summary
- [ ] Confirm `prod-claude-agent` App Runner service shows a new deployment in the AWS console

🤖 Generated with [Claude Code](https://claude.com/claude-code)