### PR TITLE
feat(#29): Configure BrainTrust telemetry capture

### DIFF
--- a/web-api/.env.example
+++ b/web-api/.env.example
@@ -16,6 +16,10 @@ ELEVEN_API_KEY=
 SONIOX_API_KEY=
 WEBHOOK_BASE_URL=http://localhost:8000
 
+# BrainTrust Telemetry (optional — logs a warning if not set)
+BRAINTRUST_API_KEY=
+BRAINTRUST_PROJECT=mishmish.ai
+
 # Server Configuration (optional)
 HOST=0.0.0.0
 PORT=8000

--- a/web-api/main.py
+++ b/web-api/main.py
@@ -16,12 +16,14 @@ from routes.realtime_pipecat import router as realtime_pipecat_router
 from routes.content import router as content_router
 from routes.webhooks import router as webhooks_router
 from routes.admin import router as admin_router
+from services.telemetry import setup_telemetry
 
 # Load environment variables from .env file in the same directory as this script
 # Use override=True to ensure this .env takes precedence over parent directory .env files
 env_path = Path(__file__).parent / ".env"
 load_dotenv(dotenv_path=env_path, override=True)
 
+setup_telemetry()
 
 app = FastAPI(
     title="mishmish.ai API",

--- a/web-api/pyproject.toml
+++ b/web-api/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "httpx>=0.28.1",
     "supabase>=2.24.0",
     "debugpy>=1.8.0",
+    "braintrust>=0.9.0",
 ]
 
 [project.optional-dependencies]

--- a/web-api/routes/admin.py
+++ b/web-api/routes/admin.py
@@ -12,6 +12,7 @@ from services import session_service, context_service, scaffolding_service
 from services.agent_session import AgentSession
 from services.supabase_client import get_supabase_admin_client
 from services.context_service import create_context, get_context, delete_context
+from services.telemetry import admin_span
 from agent.tutor.tutor_agent import agent
 from agents import Runner
 
@@ -128,7 +129,8 @@ async def admin_chat(
         raise HTTPException(status_code=404, detail=f"Admin session not found: {session_id}")
 
     context = get_context(session_id)
-    result = await Runner.run(agent, request.message, session=session, context=context)
+    with admin_span("admin_chat"):
+        result = await Runner.run(agent, request.message, session=session, context=context)
 
     # Serialize new_items (messages, tool calls, etc.)
     messages: list[Any] = []

--- a/web-api/services/agent_service.py
+++ b/web-api/services/agent_service.py
@@ -7,6 +7,7 @@ from fastapi import WebSocket
 from agent.tutor.tutor_agent import agent
 from .context_service import get_context
 from .session_service import get_session
+from .telemetry import user_span
 from .websocket_service import Message, send_message, send_audio_message
 from .tts_service import get_tts_service
 from .transcript_service import create_transcript_message
@@ -35,8 +36,9 @@ async def generate_agent_response(session_id: str, user_message: str, user_acces
     # Look up the context
     context = get_context(session_id)
 
-    # Run the agent
-    result = await Runner.run(agent, user_message, session=session, context=context)
+    # Run the agent, tagged as a user request for telemetry
+    with user_span("user_chat"):
+        result = await Runner.run(agent, user_message, session=session, context=context)
 
     return result.final_output
 
@@ -82,14 +84,15 @@ async def generate_agent_followup(session_id: str, user_access_token: str | None
     # Create run config with the callback
     run_config = RunConfig(session_input_callback=session_input_callback)
 
-    # Run the agent with the system message as input
-    result = await Runner.run(
-        agent,
-        [system_message],
-        session=session,
-        context=context,
-        run_config=run_config
-    )
+    # Run the agent with the system message as input, tagged as a user request
+    with user_span("user_followup"):
+        result = await Runner.run(
+            agent,
+            [system_message],
+            session=session,
+            context=context,
+            run_config=run_config
+        )
 
     return result.final_output
 

--- a/web-api/services/telemetry.py
+++ b/web-api/services/telemetry.py
@@ -1,0 +1,85 @@
+"""BrainTrust telemetry service for LLM request observability."""
+
+import os
+from contextlib import contextmanager
+from typing import Generator
+
+from loguru import logger
+
+_telemetry_enabled = False
+
+
+def setup_telemetry() -> None:
+    """Initialize BrainTrust telemetry if BRAINTRUST_API_KEY is configured.
+
+    Logs a warning and returns without crashing if the key is absent.
+    When enabled, auto-instruments OpenAI so all LLM calls are captured.
+    """
+    global _telemetry_enabled
+
+    api_key = os.getenv("BRAINTRUST_API_KEY")
+    if not api_key:
+        logger.warning(
+            "BRAINTRUST_API_KEY not set — BrainTrust telemetry disabled. "
+            "Set BRAINTRUST_API_KEY to enable LLM observability."
+        )
+        return
+
+    try:
+        import braintrust
+
+        project = os.getenv("BRAINTRUST_PROJECT", "mishmish.ai")
+        braintrust.init_logger(project=project, api_key=api_key, async_flush=True)
+        braintrust.auto_instrument(openai=True)
+
+        _telemetry_enabled = True
+        logger.info(f"BrainTrust telemetry enabled (project={project!r})")
+    except Exception as exc:
+        logger.warning(f"Failed to initialize BrainTrust telemetry: {exc}")
+
+
+def is_enabled() -> bool:
+    """Return True if BrainTrust telemetry was successfully initialized."""
+    return _telemetry_enabled
+
+
+@contextmanager
+def admin_span(name: str) -> Generator[None, None, None]:
+    """Context manager that wraps an LLM call with an 'admin' tag in BrainTrust.
+
+    Usage::
+
+        with admin_span("admin_chat"):
+            result = await Runner.run(agent, message)
+
+    If telemetry is disabled this is a no-op.
+    """
+    if not _telemetry_enabled:
+        yield
+        return
+
+    import braintrust
+
+    with braintrust.start_span(name=name, tags=["admin"]):
+        yield
+
+
+@contextmanager
+def user_span(name: str) -> Generator[None, None, None]:
+    """Context manager that wraps an LLM call with a 'user' tag in BrainTrust.
+
+    Usage::
+
+        with user_span("user_chat"):
+            result = await Runner.run(agent, message)
+
+    If telemetry is disabled this is a no-op.
+    """
+    if not _telemetry_enabled:
+        yield
+        return
+
+    import braintrust
+
+    with braintrust.start_span(name=name, tags=["user"]):
+        yield

--- a/web-api/tests/test_services/test_telemetry.py
+++ b/web-api/tests/test_services/test_telemetry.py
@@ -1,0 +1,173 @@
+"""Tests for the BrainTrust telemetry service."""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestSetupTelemetry:
+    """Tests for setup_telemetry()."""
+
+    def test_no_api_key_logs_warning_and_stays_disabled(self):
+        """When BRAINTRUST_API_KEY is absent, telemetry is not enabled and a warning is logged."""
+        import services.telemetry as tel
+
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("BRAINTRUST_API_KEY", None)
+            tel._telemetry_enabled = False
+
+            with patch("services.telemetry.logger") as mock_logger:
+                tel.setup_telemetry()
+
+            mock_logger.warning.assert_called_once()
+            warning_msg = mock_logger.warning.call_args[0][0]
+            assert "BRAINTRUST_API_KEY" in warning_msg
+
+        assert tel._telemetry_enabled is False
+
+    def test_with_api_key_enables_telemetry(self):
+        """When BRAINTRUST_API_KEY is set, telemetry is initialized and enabled."""
+        import services.telemetry as tel
+
+        mock_braintrust = MagicMock()
+
+        with patch.dict(os.environ, {"BRAINTRUST_API_KEY": "test-key", "BRAINTRUST_PROJECT": "test-project"}):
+            tel._telemetry_enabled = False
+
+            with patch.dict("sys.modules", {"braintrust": mock_braintrust}):
+                tel.setup_telemetry()
+
+        assert tel._telemetry_enabled is True
+        mock_braintrust.init_logger.assert_called_once_with(
+            project="test-project",
+            api_key="test-key",
+            async_flush=True,
+        )
+        mock_braintrust.auto_instrument.assert_called_once_with(openai=True)
+
+    def test_with_api_key_uses_default_project(self):
+        """When BRAINTRUST_PROJECT is not set, defaults to 'mishmish.ai'."""
+        import services.telemetry as tel
+
+        mock_braintrust = MagicMock()
+
+        env = {"BRAINTRUST_API_KEY": "test-key"}
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("BRAINTRUST_PROJECT", None)
+            tel._telemetry_enabled = False
+
+            with patch.dict("sys.modules", {"braintrust": mock_braintrust}):
+                tel.setup_telemetry()
+
+        mock_braintrust.init_logger.assert_called_once_with(
+            project="mishmish.ai",
+            api_key="test-key",
+            async_flush=True,
+        )
+
+    def test_braintrust_exception_logs_warning_and_stays_disabled(self):
+        """When braintrust raises during init, telemetry stays disabled and a warning is logged."""
+        import services.telemetry as tel
+
+        mock_braintrust = MagicMock()
+        mock_braintrust.init_logger.side_effect = RuntimeError("connection refused")
+
+        with patch.dict(os.environ, {"BRAINTRUST_API_KEY": "test-key"}):
+            tel._telemetry_enabled = False
+
+            with patch("services.telemetry.logger") as mock_logger:
+                with patch.dict("sys.modules", {"braintrust": mock_braintrust}):
+                    tel.setup_telemetry()
+
+            mock_logger.warning.assert_called_once()
+            warning_msg = mock_logger.warning.call_args[0][0]
+            assert "Failed to initialize" in warning_msg
+
+        assert tel._telemetry_enabled is False
+
+
+class TestIsEnabled:
+    """Tests for is_enabled()."""
+
+    def test_returns_false_when_not_initialized(self):
+        import services.telemetry as tel
+        tel._telemetry_enabled = False
+        assert tel.is_enabled() is False
+
+    def test_returns_true_when_initialized(self):
+        import services.telemetry as tel
+        tel._telemetry_enabled = True
+        assert tel.is_enabled() is True
+        tel._telemetry_enabled = False
+
+
+class TestAdminSpan:
+    """Tests for admin_span() context manager."""
+
+    def test_noop_when_telemetry_disabled(self):
+        """admin_span is a no-op and does not call braintrust when disabled."""
+        import services.telemetry as tel
+        tel._telemetry_enabled = False
+
+        executed = []
+        with tel.admin_span("admin_chat"):
+            executed.append(True)
+
+        assert executed == [True]
+
+    def test_creates_span_with_admin_tag_when_enabled(self):
+        """admin_span creates a BrainTrust span tagged 'admin' when telemetry is enabled."""
+        import services.telemetry as tel
+        tel._telemetry_enabled = True
+
+        mock_span = MagicMock()
+        mock_span.__enter__ = MagicMock(return_value=mock_span)
+        mock_span.__exit__ = MagicMock(return_value=False)
+
+        mock_braintrust = MagicMock()
+        mock_braintrust.start_span.return_value = mock_span
+
+        executed = []
+        with patch.dict("sys.modules", {"braintrust": mock_braintrust}):
+            with tel.admin_span("admin_chat"):
+                executed.append(True)
+
+        assert executed == [True]
+        mock_braintrust.start_span.assert_called_once_with(name="admin_chat", tags=["admin"])
+        tel._telemetry_enabled = False
+
+
+class TestUserSpan:
+    """Tests for user_span() context manager."""
+
+    def test_noop_when_telemetry_disabled(self):
+        """user_span is a no-op when disabled."""
+        import services.telemetry as tel
+        tel._telemetry_enabled = False
+
+        executed = []
+        with tel.user_span("user_chat"):
+            executed.append(True)
+
+        assert executed == [True]
+
+    def test_creates_span_with_user_tag_when_enabled(self):
+        """user_span creates a BrainTrust span tagged 'user' when telemetry is enabled."""
+        import services.telemetry as tel
+        tel._telemetry_enabled = True
+
+        mock_span = MagicMock()
+        mock_span.__enter__ = MagicMock(return_value=mock_span)
+        mock_span.__exit__ = MagicMock(return_value=False)
+
+        mock_braintrust = MagicMock()
+        mock_braintrust.start_span.return_value = mock_span
+
+        executed = []
+        with patch.dict("sys.modules", {"braintrust": mock_braintrust}):
+            with tel.user_span("user_chat"):
+                executed.append(True)
+
+        assert executed == [True]
+        mock_braintrust.start_span.assert_called_once_with(name="user_chat", tags=["user"])
+        tel._telemetry_enabled = False


### PR DESCRIPTION
Closes #29

Configure BrainTrust to capture telemetry on all LLM requests. Make it subject to the presence of the required API keys in the env vars so that it logs a warning but does not crash the application if keys are not configured. Make changes in the API only. Tag admin LLM requests as such, and user requests as such, so they can be filtered.

---
This PR was generated autonomously by Claude Code