### PR TITLE
feat(#49): Prod deployment in AWS does not support websocket connections

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -61,6 +61,7 @@ jobs:
     environment: production
     outputs:
       api_url: ${{ steps.outputs.outputs.api_url }}
+      api_cf_domain: ${{ steps.outputs.outputs.api_cf_domain }}
       claude_agent_url: ${{ steps.outputs.outputs.claude_agent_url }}
       web_app_url: ${{ steps.outputs.outputs.web_app_url }}
       admin_url: ${{ steps.outputs.outputs.admin_url }}
@@ -132,6 +133,7 @@ jobs:
           }
 
           echo "api_url=$(get_output ApiUrl)" >> "$GITHUB_OUTPUT"
+          echo "api_cf_domain=$(get_output ApiCloudFrontDomain)" >> "$GITHUB_OUTPUT"
           echo "claude_agent_url=$(get_output ClaudeAgentUrl)" >> "$GITHUB_OUTPUT"
           echo "web_app_url=$(get_output WebAppUrl)" >> "$GITHUB_OUTPUT"
           echo "admin_url=$(get_output AdminUrl)" >> "$GITHUB_OUTPUT"
@@ -144,6 +146,11 @@ jobs:
 
       - name: Associate App Runner custom domains
         run: |
+          # NOTE: api.mishmish.ai is now served via CloudFront (for WebSocket support).
+          # Do NOT associate api.mishmish.ai with App Runner — CloudFront is the entry
+          # point and uses App Runner's default service URL as its origin internally.
+          # Only claude.mishmish.ai is associated with App Runner directly.
+
           associate_domain() {
             local SERVICE_NAME="$1"
             local DOMAIN="$2"
@@ -183,7 +190,6 @@ jobs:
             echo '```' >> "$GITHUB_STEP_SUMMARY"
           }
 
-          associate_domain "prod-api" "api.mishmish.ai"
           associate_domain "prod-claude-agent" "claude.mishmish.ai"
 
   # ------------------------------------------------------------------
@@ -259,7 +265,7 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Service | Custom Domain | CloudFront/App Runner URL |" >> "$GITHUB_STEP_SUMMARY"
           echo "|---------|---------------|--------------------------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| API | https://api.mishmish.ai | ${{ needs.deploy-infra.outputs.api_url }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| API (via CloudFront) | https://api.mishmish.ai | ${{ needs.deploy-infra.outputs.api_url }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Claude Agent | https://claude.mishmish.ai | ${{ needs.deploy-infra.outputs.claude_agent_url }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Web App | https://mishmish.ai | https://${{ needs.deploy-infra.outputs.web_app_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Admin | https://admin.mishmish.ai | https://${{ needs.deploy-infra.outputs.admin_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
@@ -270,5 +276,8 @@ jobs:
           echo "| mishmish.ai | ALIAS/ANAME | ${{ needs.deploy-infra.outputs.web_app_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| www.mishmish.ai | CNAME | ${{ needs.deploy-infra.outputs.web_app_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| admin.mishmish.ai | CNAME | ${{ needs.deploy-infra.outputs.admin_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| api.mishmish.ai | CNAME | (see App Runner DNS records section above) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| api.mishmish.ai | CNAME | ${{ needs.deploy-infra.outputs.api_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| claude.mishmish.ai | CNAME | (see App Runner DNS records section above) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "> **Note:** \`api.mishmish.ai\` now points to CloudFront (not App Runner directly)." >> "$GITHUB_STEP_SUMMARY"
+          echo "> CloudFront proxies WebSocket connections that App Runner cannot handle natively." >> "$GITHUB_STEP_SUMMARY"

--- a/infra/preview/template.yaml
+++ b/infra/preview/template.yaml
@@ -106,6 +106,55 @@ Resources:
           Value: !Ref PrNumber
 
   # ============================================================
+  # API CloudFront Distribution (WebSocket proxy)
+  #
+  # AWS App Runner does not support WebSocket connections via the
+  # HTTP Upgrade protocol. CloudFront proxies WebSocket traffic
+  # transparently to the App Runner origin, enabling wss:// connections.
+  # ============================================================
+
+  ApiDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Comment: !Sub "Preview PR #${PrNumber} - API (WebSocket proxy)"
+        PriceClass: PriceClass_100
+        Origins:
+          - Id: ApiOrigin
+            DomainName: !GetAtt ApiService.ServiceUrl
+            CustomOriginConfig:
+              HTTPSPort: 443
+              OriginProtocolPolicy: https-only
+              OriginSSLProtocols:
+                - TLSv1.2
+        DefaultCacheBehavior:
+          TargetOriginId: ApiOrigin
+          ViewerProtocolPolicy: redirect-to-https
+          # CachingDisabled - required for API/WebSocket endpoints
+          CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
+          # AllViewerExceptHostHeader - forwards all viewer headers including
+          # WebSocket upgrade headers (Upgrade, Connection, Sec-WebSocket-*)
+          OriginRequestPolicyId: 216adef6-5c7f-47e4-b989-5492eafa07d3
+          AllowedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+            - PUT
+            - POST
+            - PATCH
+            - DELETE
+          CachedMethods:
+            - GET
+            - HEAD
+          Compress: true
+      Tags:
+        - Key: Environment
+          Value: preview
+        - Key: PrNumber
+          Value: !Ref PrNumber
+
+  # ============================================================
   # Web App (S3 + CloudFront)
   # ============================================================
 
@@ -273,8 +322,10 @@ Resources:
 
 Outputs:
   ApiUrl:
-    Description: App Runner API URL
-    Value: !Sub "https://${ApiService.ServiceUrl}"
+    Description: >
+      API URL via CloudFront (WebSocket-enabled). Use this as VITE_API_URL.
+      CloudFront proxies WebSocket upgrade requests that App Runner cannot handle.
+    Value: !Sub "https://${ApiDistribution.DomainName}"
 
   WebAppUrl:
     Description: Web app CloudFront URL

--- a/infra/prod/template.yaml
+++ b/infra/prod/template.yaml
@@ -197,6 +197,69 @@ Resources:
           Value: production
 
   # ============================================================
+  # API CloudFront Distribution (WebSocket proxy)
+  #
+  # AWS App Runner does not support WebSocket connections via the
+  # HTTP Upgrade protocol. CloudFront proxies WebSocket traffic
+  # transparently to the App Runner origin, enabling wss:// connections.
+  #
+  # Cache policy:    CachingDisabled (no caching for API calls)
+  # Origin policy:   AllViewerExceptHostHeader (forwards WebSocket upgrade
+  #                  headers: Upgrade, Connection, Sec-WebSocket-*)
+  # ============================================================
+
+  ApiDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Comment: Production - API (WebSocket proxy for App Runner)
+        PriceClass: PriceClass_100
+        Aliases: !If
+          - HasCustomDomain
+          - [api.mishmish.ai]
+          - !Ref AWS::NoValue
+        ViewerCertificate: !If
+          - HasCustomDomain
+          - AcmCertificateArn: !Ref AcmCertificateArn
+            SslSupportMethod: sni-only
+            MinimumProtocolVersion: TLSv1.2_2021
+          - CloudFrontDefaultCertificate: true
+        Origins:
+          - Id: ApiOrigin
+            DomainName: !GetAtt ApiService.ServiceUrl
+            CustomOriginConfig:
+              HTTPSPort: 443
+              OriginProtocolPolicy: https-only
+              OriginSSLProtocols:
+                - TLSv1.2
+        DefaultCacheBehavior:
+          TargetOriginId: ApiOrigin
+          ViewerProtocolPolicy: redirect-to-https
+          # CachingDisabled - required for API/WebSocket endpoints
+          CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
+          # AllViewerExceptHostHeader - forwards all viewer headers including
+          # WebSocket upgrade headers (Upgrade, Connection, Sec-WebSocket-*)
+          # but lets CloudFront set Host to the App Runner origin URL so
+          # App Runner can route the request correctly.
+          OriginRequestPolicyId: 216adef6-5c7f-47e4-b989-5492eafa07d3
+          AllowedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+            - PUT
+            - POST
+            - PATCH
+            - DELETE
+          CachedMethods:
+            - GET
+            - HEAD
+          Compress: true
+      Tags:
+        - Key: Environment
+          Value: production
+
+  # ============================================================
   # Web App (S3 + CloudFront)
   # ============================================================
 
@@ -376,7 +439,22 @@ Resources:
 
 Outputs:
   ApiUrl:
-    Description: App Runner API URL
+    Description: >
+      API URL via CloudFront (WebSocket-enabled). Use this as VITE_API_URL.
+      ws:// / wss:// connections work because CloudFront proxies WebSocket
+      upgrade requests that App Runner's load balancer cannot handle natively.
+    Value: !Sub "https://${ApiDistribution.DomainName}"
+
+  ApiCloudFrontDomain:
+    Description: >
+      API CloudFront domain (point api.mishmish.ai here via CNAME).
+      Do NOT associate api.mishmish.ai with App Runner directly — use this value.
+    Value: !GetAtt ApiDistribution.DomainName
+
+  AppRunnerApiUrl:
+    Description: >
+      Direct App Runner URL (internal use only — no WebSocket support).
+      CloudFront uses this as its origin; do not expose this to clients.
     Value: !Sub "https://${ApiService.ServiceUrl}"
 
   ClaudeAgentUrl:


### PR DESCRIPTION
Closes #49

The web app uses websockets (and webrtc) but it looks like the api is not deployed in a way that allows for websocket ingress, maybe the ports or something else related to the hosting configuration for the app in aws?

---
This PR was generated autonomously by Claude Code