### PR TITLE
feat(config): use AWS Secrets Manager for API secrets

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -99,16 +99,12 @@ jobs:
             --stack-name "arabic-voice-agent-prod" \
             --template-file infra/prod/template.yaml \
             --no-fail-on-empty-changeset \
+            --capabilities CAPABILITY_NAMED_IAM \
             --parameter-overrides \
               AcmCertificateArn="${{ secrets.AWS_ACM_CERTIFICATE_ARN }}" \
               EcrImageUri="${{ needs.build-api-image.outputs.image_uri }}" \
               AppRunnerEcrRoleArn="${{ secrets.AWS_APP_RUNNER_ECR_ROLE_ARN }}" \
-              SupabaseUrl="${{ secrets.SUPABASE_URL }}" \
-              SupabasePublishableKey="${{ secrets.SUPABASE_PUBLISHABLE_KEY }}" \
-              SupabaseSecretKey="${{ secrets.SUPABASE_SECRET_KEY }}" \
-              OpenaiApiKey="${{ secrets.OPENAI_API_KEY }}" \
-              SonioxApiKey="${{ secrets.SONIOX_API_KEY }}" \
-              ElevenApiKey="${{ secrets.ELEVEN_API_KEY }}"
+              ApiSecretArn="${{ secrets.API_SECRET_ARN }}"
 
       - name: Get stack outputs
         id: outputs

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -179,6 +179,7 @@ jobs:
             --stack-name "preview-pr-${{ github.event.pull_request.number }}" \
             --template-file infra/preview/template.yaml \
             --no-fail-on-empty-changeset \
+            --capabilities CAPABILITY_NAMED_IAM \
             --parameter-overrides \
               PrNumber="${{ github.event.pull_request.number }}" \
               EcrImageUri="${{ needs.build-api-image.outputs.image_uri }}" \
@@ -186,9 +187,7 @@ jobs:
               SupabaseUrl="${{ needs.supabase-credentials.outputs.url }}" \
               SupabaseAnonKey="${{ steps.supabase.outputs.anon_key }}" \
               SupabaseServiceKey="${{ steps.supabase.outputs.service_key }}" \
-              OpenaiApiKey="${{ secrets.OPENAI_API_KEY }}" \
-              SonioxApiKey="${{ secrets.SONIOX_API_KEY }}" \
-              ElevenApiKey="${{ secrets.ELEVEN_API_KEY }}"
+              ApiSecretArn="${{ secrets.PREVIEW_API_SECRET_ARN }}"
 
       - name: Get stack outputs
         id: outputs

--- a/infra/preview/template.yaml
+++ b/infra/preview/template.yaml
@@ -31,23 +31,41 @@ Parameters:
     NoEcho: true
     Description: Supabase branch service role key
 
-  # --- API keys (from GitHub secrets) ---
-  OpenaiApiKey:
+  # --- API secrets (from AWS Secrets Manager) ---
+  ApiSecretArn:
     Type: String
-    NoEcho: true
-    Description: OpenAI API key
-
-  SonioxApiKey:
-    Type: String
-    NoEcho: true
-    Description: Soniox API key
-
-  ElevenApiKey:
-    Type: String
-    NoEcho: true
-    Description: ElevenLabs API key
+    Description: >
+      ARN of the AWS Secrets Manager secret containing API secrets
+      (mishmish/preview/api). Expected keys: OPENAI_API_KEY, SONIOX_API_KEY,
+      ELEVEN_API_KEY.
 
 Resources:
+  # ============================================================
+  # API Service — Instance Role (Secrets Manager access)
+  # ============================================================
+
+  ApiInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "preview-api-pr-${PrNumber}-instance-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: tasks.apprunner.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: ApiSecretsAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                  - secretsmanager:DescribeSecret
+                Resource: !Ref ApiSecretArn
+
   # ============================================================
   # API Service (App Runner)
   # ============================================================
@@ -80,17 +98,19 @@ Resources:
                 Value: !Ref SupabaseAnonKey
               - Name: SUPABASE_SECRET_KEY
                 Value: !Ref SupabaseServiceKey
-              - Name: OPENAI_API_KEY
-                Value: !Ref OpenaiApiKey
-              - Name: SONIOX_API_KEY
-                Value: !Ref SonioxApiKey
-              - Name: ELEVEN_API_KEY
-                Value: !Ref ElevenApiKey
               - Name: PORT
                 Value: "8000"
+            RuntimeEnvironmentSecrets:
+              - Name: OPENAI_API_KEY
+                Value: !Sub "${ApiSecretArn}:OPENAI_API_KEY::"
+              - Name: SONIOX_API_KEY
+                Value: !Sub "${ApiSecretArn}:SONIOX_API_KEY::"
+              - Name: ELEVEN_API_KEY
+                Value: !Sub "${ApiSecretArn}:ELEVEN_API_KEY::"
       InstanceConfiguration:
         Cpu: "1024"
         Memory: "2048"
+        InstanceRoleArn: !GetAtt ApiInstanceRole.Arn
       AutoScalingConfigurationArn: !GetAtt ApiAutoScalingConfig.AutoScalingConfigurationArn
       HealthCheckConfiguration:
         Protocol: HTTP

--- a/infra/prod/template.yaml
+++ b/infra/prod/template.yaml
@@ -21,41 +21,43 @@ Parameters:
     Type: String
     Description: ARN of the IAM role that allows App Runner to pull from ECR
 
-  # --- Supabase (production, static secrets) ---
-  SupabaseUrl:
+  ApiSecretArn:
     Type: String
-    Description: Supabase production URL
-
-  SupabasePublishableKey:
-    Type: String
-    NoEcho: true
-    Description: Supabase production publishable key
-
-  SupabaseSecretKey:
-    Type: String
-    NoEcho: true
-    Description: Supabase production secret key
-
-  # --- API keys ---
-  OpenaiApiKey:
-    Type: String
-    NoEcho: true
-    Description: OpenAI API key
-
-  SonioxApiKey:
-    Type: String
-    NoEcho: true
-    Description: Soniox API key
-
-  ElevenApiKey:
-    Type: String
-    NoEcho: true
-    Description: ElevenLabs API key
+    Description: >
+      ARN of the AWS Secrets Manager secret containing API secrets
+      (mishmish/prod/api). Expected keys: SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY,
+      SUPABASE_SECRET_KEY, OPENAI_API_KEY, SONIOX_API_KEY, ELEVEN_API_KEY.
 
 Conditions:
   HasCustomDomain: !Not [!Equals [!Ref AcmCertificateArn, ""]]
 
 Resources:
+  # ============================================================
+  # API Service — Instance Role (Secrets Manager access)
+  # ============================================================
+
+  ApiInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: prod-api-instance-role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: tasks.apprunner.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: ApiSecretsAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                  - secretsmanager:DescribeSecret
+                Resource: !Ref ApiSecretArn
+
   # ============================================================
   # API Service (App Runner)
   # ============================================================
@@ -82,23 +84,25 @@ Resources:
           ImageConfiguration:
             Port: "8000"
             RuntimeEnvironmentVariables:
-              - Name: SUPABASE_URL
-                Value: !Ref SupabaseUrl
-              - Name: SUPABASE_PUBLISHABLE_KEY
-                Value: !Ref SupabasePublishableKey
-              - Name: SUPABASE_SECRET_KEY
-                Value: !Ref SupabaseSecretKey
-              - Name: OPENAI_API_KEY
-                Value: !Ref OpenaiApiKey
-              - Name: SONIOX_API_KEY
-                Value: !Ref SonioxApiKey
-              - Name: ELEVEN_API_KEY
-                Value: !Ref ElevenApiKey
               - Name: PORT
                 Value: "8000"
+            RuntimeEnvironmentSecrets:
+              - Name: SUPABASE_URL
+                Value: !Sub "${ApiSecretArn}:SUPABASE_URL::"
+              - Name: SUPABASE_PUBLISHABLE_KEY
+                Value: !Sub "${ApiSecretArn}:SUPABASE_PUBLISHABLE_KEY::"
+              - Name: SUPABASE_SECRET_KEY
+                Value: !Sub "${ApiSecretArn}:SUPABASE_SECRET_KEY::"
+              - Name: OPENAI_API_KEY
+                Value: !Sub "${ApiSecretArn}:OPENAI_API_KEY::"
+              - Name: SONIOX_API_KEY
+                Value: !Sub "${ApiSecretArn}:SONIOX_API_KEY::"
+              - Name: ELEVEN_API_KEY
+                Value: !Sub "${ApiSecretArn}:ELEVEN_API_KEY::"
       InstanceConfiguration:
         Cpu: "1024"
         Memory: "2048"
+        InstanceRoleArn: !GetAtt ApiInstanceRole.Arn
       AutoScalingConfigurationArn: !GetAtt ApiAutoScalingConfig.AutoScalingConfigurationArn
       HealthCheckConfiguration:
         Protocol: HTTP


### PR DESCRIPTION
## Summary
- Replace inline CloudFormation parameters with `RuntimeEnvironmentSecrets` referencing `mishmish/prod/api` and `mishmish/preview/api` in AWS Secrets Manager
- Add IAM instance roles (`prod-api-instance-role`, `preview-api-pr-{N}-instance-role`) granting App Runner `secretsmanager:GetSecretValue` access
- Prod: all 6 secrets (Supabase + API keys) from Secrets Manager; Preview: 3 API keys from Secrets Manager, Supabase stays dynamic per PR branch
- GitHub secrets `API_SECRET_ARN` (production) and `PREVIEW_API_SECRET_ARN` (dev) already configured
- AWS Secrets Manager secrets already created and populated

## Test plan
- [ ] Trigger prod deploy and verify App Runner starts with secrets from `mishmish/prod/api`
- [ ] Open a test PR and verify preview stack deploys with secrets from `mishmish/preview/api`
- [ ] Confirm API `/health` endpoint responds on both environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)