### PR TITLE
feat(infra): migrate API from App Runner to ECS Fargate + ALB for WebSocket support

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -77,6 +77,19 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Get bootstrap stack outputs
+        id: bootstrap
+        run: |
+          get_output() {
+            aws cloudformation describe-stacks \
+              --stack-name "arabic-voice-agent-bootstrap" \
+              --query "Stacks[0].Outputs[?OutputKey=='$1'].OutputValue" \
+              --output text
+          }
+          echo "vpc_id=$(get_output VpcId)" >> "$GITHUB_OUTPUT"
+          echo "subnet_ids=$(get_output SubnetIds)" >> "$GITHUB_OUTPUT"
+          echo "ecs_execution_role_arn=$(get_output EcsTaskExecutionRoleArn)" >> "$GITHUB_OUTPUT"
+
       - name: Clean up failed stack if needed
         run: |
           STACK_NAME="arabic-voice-agent-prod"
@@ -103,7 +116,10 @@ jobs:
             --parameter-overrides \
               AcmCertificateArn="${{ secrets.AWS_ACM_CERTIFICATE_ARN }}" \
               EcrImageUri="${{ needs.build-api-image.outputs.image_uri }}" \
-              AppRunnerEcrRoleArn="${{ secrets.AWS_APP_RUNNER_ECR_ROLE_ARN }}" \
+              VpcId="${{ steps.bootstrap.outputs.vpc_id }}" \
+              SubnetIds="${{ steps.bootstrap.outputs.subnet_ids }}" \
+              EcsTaskExecutionRoleArn="${{ steps.bootstrap.outputs.ecs_execution_role_arn }}" \
+              ApiAcmCertificateArn="${{ secrets.API_ACM_CERTIFICATE_ARN }}" \
               ApiSecretArn="${{ secrets.API_SECRET_ARN }}"
 
       - name: Get stack outputs
@@ -126,41 +142,16 @@ jobs:
           echo "web_app_cf_domain=$(get_output WebAppCloudFrontDomain)" >> "$GITHUB_OUTPUT"
           echo "admin_cf_domain=$(get_output AdminCloudFrontDomain)" >> "$GITHUB_OUTPUT"
 
-      - name: Associate App Runner custom domain
+      - name: Print API ALB DNS name
         run: |
-          SERVICE_ARN=$(aws apprunner list-services \
-            --query "ServiceSummaryList[?ServiceName=='prod-api'].ServiceArn" \
+          ALB_DNS=$(aws cloudformation describe-stacks \
+            --stack-name "arabic-voice-agent-prod" \
+            --query "Stacks[0].Outputs[?OutputKey=='ApiAlbDnsName'].OutputValue" \
             --output text)
 
-          if [ -z "$SERVICE_ARN" ]; then
-            echo "Could not find prod-api service, skipping custom domain association"
-            exit 0
-          fi
-
-          EXISTING=$(aws apprunner describe-custom-domains \
-            --service-arn "$SERVICE_ARN" \
-            --output json 2>/dev/null \
-            | grep -o '"api\.mishmish\.ai"' || true)
-
-          if [ -z "$EXISTING" ]; then
-            echo "Associating api.mishmish.ai with App Runner..."
-            aws apprunner associate-custom-domain \
-              --service-arn "$SERVICE_ARN" \
-              --domain-name "api.mishmish.ai" \
-              || echo "Warning: domain association returned an error (may already be pending — check App Runner console)"
-          else
-            echo "api.mishmish.ai is already associated"
-          fi
-
-          DOMAIN_INFO=$(aws apprunner describe-custom-domains \
-            --service-arn "$SERVICE_ARN" \
-            --query "CustomDomains[?DomainName=='api.mishmish.ai']" \
-            --output json 2>/dev/null || echo "[]")
-
-          echo "### api.mishmish.ai DNS records" >> "$GITHUB_STEP_SUMMARY"
-          echo '```json' >> "$GITHUB_STEP_SUMMARY"
-          echo "$DOMAIN_INFO" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "### API DNS record required" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Point \`api.mishmish.ai\` CNAME to: \`$ALB_DNS\`" >> "$GITHUB_STEP_SUMMARY"
 
   # ------------------------------------------------------------------
   # Job 3: Build static sites and upload to S3
@@ -247,4 +238,4 @@ jobs:
           echo "| mishmish.ai | ALIAS/ANAME | ${{ needs.deploy-infra.outputs.web_app_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| www.mishmish.ai | CNAME | ${{ needs.deploy-infra.outputs.web_app_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| admin.mishmish.ai | CNAME | ${{ needs.deploy-infra.outputs.admin_cf_domain }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| api.mishmish.ai | CNAME | (see App Runner DNS records section above) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| api.mishmish.ai | CNAME | (see API DNS record section above) |" >> "$GITHUB_STEP_SUMMARY"

--- a/infra/bootstrap/template.yaml
+++ b/infra/bootstrap/template.yaml
@@ -19,6 +19,99 @@ Parameters:
     Description: ARN of the existing GitHub OIDC provider in this account
 
 Resources:
+  # --- VPC (shared by ECS/ALB in prod and preview) ---
+
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: arabic-voice-agent
+
+  SubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: 10.0.1.0/24
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: arabic-voice-agent-public-a
+
+  SubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: 10.0.2.0/24
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: arabic-voice-agent-public-b
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+
+  VpcGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref Vpc
+      InternetGatewayId: !Ref InternetGateway
+
+  RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: VpcGatewayAttachment
+    Properties:
+      RouteTableId: !Ref RouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  SubnetARouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref SubnetA
+      RouteTableId: !Ref RouteTable
+
+  SubnetBRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref SubnetB
+      RouteTableId: !Ref RouteTable
+
+  # --- ECS Task Execution Role (shared; pulls ECR images, writes logs, reads secrets) ---
+
+  EcsTaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: ecs-task-execution
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Policies:
+        - PolicyName: SecretsManagerRead
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: "*"
+
   # --- ECR Repositories ---
   EcrRepository:
     Type: AWS::ECR::Repository
@@ -214,11 +307,111 @@ Resources:
                   - !Sub "arn:aws:cloudformation:*:${AWS::AccountId}:stack/preview-pr-*/*"
                   - !Sub "arn:aws:cloudformation:*:${AWS::AccountId}:stack/arabic-voice-agent-prod/*"
 
-              # IAM - pass roles to App Runner
+              # ECS - manage clusters, services, task definitions
+              - Sid: Ecs
+                Effect: Allow
+                Action:
+                  - ecs:CreateCluster
+                  - ecs:DeleteCluster
+                  - ecs:DescribeClusters
+                  - ecs:RegisterTaskDefinition
+                  - ecs:DeregisterTaskDefinition
+                  - ecs:DescribeTaskDefinition
+                  - ecs:CreateService
+                  - ecs:UpdateService
+                  - ecs:DeleteService
+                  - ecs:DescribeServices
+                  - ecs:ListServices
+                  - ecs:TagResource
+                  - ecs:UntagResource
+                  - ecs:ListTagsForResource
+                Resource: "*"
+
+              # ALB - manage load balancers, listeners, and target groups
+              - Sid: Elb
+                Effect: Allow
+                Action:
+                  - elasticloadbalancing:CreateLoadBalancer
+                  - elasticloadbalancing:DeleteLoadBalancer
+                  - elasticloadbalancing:DescribeLoadBalancers
+                  - elasticloadbalancing:DescribeLoadBalancerAttributes
+                  - elasticloadbalancing:ModifyLoadBalancerAttributes
+                  - elasticloadbalancing:SetSecurityGroups
+                  - elasticloadbalancing:CreateListener
+                  - elasticloadbalancing:DeleteListener
+                  - elasticloadbalancing:DescribeListeners
+                  - elasticloadbalancing:ModifyListener
+                  - elasticloadbalancing:CreateTargetGroup
+                  - elasticloadbalancing:DeleteTargetGroup
+                  - elasticloadbalancing:DescribeTargetGroups
+                  - elasticloadbalancing:DescribeTargetGroupAttributes
+                  - elasticloadbalancing:ModifyTargetGroup
+                  - elasticloadbalancing:ModifyTargetGroupAttributes
+                  - elasticloadbalancing:DescribeTargetHealth
+                  - elasticloadbalancing:RegisterTargets
+                  - elasticloadbalancing:DeregisterTargets
+                  - elasticloadbalancing:AddTags
+                  - elasticloadbalancing:RemoveTags
+                  - elasticloadbalancing:DescribeTags
+                Resource: "*"
+
+              # EC2 - security groups and VPC reads for ECS/ALB
+              - Sid: Ec2
+                Effect: Allow
+                Action:
+                  - ec2:CreateSecurityGroup
+                  - ec2:DeleteSecurityGroup
+                  - ec2:DescribeSecurityGroups
+                  - ec2:AuthorizeSecurityGroupIngress
+                  - ec2:RevokeSecurityGroupIngress
+                  - ec2:AuthorizeSecurityGroupEgress
+                  - ec2:RevokeSecurityGroupEgress
+                  - ec2:DescribeVpcs
+                  - ec2:DescribeSubnets
+                  - ec2:DescribeAvailabilityZones
+                  - ec2:CreateTags
+                  - ec2:DescribeTags
+                Resource: "*"
+
+              # IAM - manage roles created inside prod/preview stacks, and pass roles
+              - Sid: IamRoles
+                Effect: Allow
+                Action:
+                  - iam:CreateRole
+                  - iam:DeleteRole
+                  - iam:GetRole
+                  - iam:PutRolePolicy
+                  - iam:DeleteRolePolicy
+                  - iam:GetRolePolicy
+                  - iam:AttachRolePolicy
+                  - iam:DetachRolePolicy
+                  - iam:TagRole
+                  - iam:UntagRole
+                  - iam:ListRolePolicies
+                  - iam:ListAttachedRolePolicies
+                Resource:
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/prod-*"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/preview-*"
+
+              # IAM - pass roles to App Runner and ECS
               - Sid: PassRole
                 Effect: Allow
                 Action: iam:PassRole
-                Resource: !GetAtt AppRunnerEcrAccessRole.Arn
+                Resource:
+                  - !GetAtt AppRunnerEcrAccessRole.Arn
+                  - !GetAtt EcsTaskExecutionRole.Arn
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/prod-*"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/preview-*"
+
+              # CloudWatch Logs - create log groups for ECS containers
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:DeleteLogGroup
+                  - logs:DescribeLogGroups
+                  - logs:PutRetentionPolicy
+                Resource: "*"
 
   # --- IAM Role for App Runner to pull from ECR ---
   AppRunnerEcrAccessRole:
@@ -251,6 +444,18 @@ Resources:
                   - !GetAtt ClaudeAgentEcrRepository.Arn
 
 Outputs:
+  VpcId:
+    Description: VPC ID for ECS/ALB resources (read dynamically by deploy workflows)
+    Value: !Ref Vpc
+
+  SubnetIds:
+    Description: Comma-separated public subnet IDs (read dynamically by deploy workflows)
+    Value: !Join [",", [!Ref SubnetA, !Ref SubnetB]]
+
+  EcsTaskExecutionRoleArn:
+    Description: ECS task execution role ARN (read dynamically by deploy workflows)
+    Value: !GetAtt EcsTaskExecutionRole.Arn
+
   EcrRepositoryUri:
     Description: ECR repository URI (set as GitHub secret ECR_REGISTRY)
     Value: !GetAtt EcrRepository.RepositoryUri

--- a/infra/prod/template.yaml
+++ b/infra/prod/template.yaml
@@ -17,9 +17,23 @@ Parameters:
     Type: String
     Description: "Full ECR image URI for web-api"
 
-  AppRunnerEcrRoleArn:
+  VpcId:
     Type: String
-    Description: ARN of the IAM role that allows App Runner to pull from ECR
+    Description: VPC ID (from bootstrap stack output VpcId)
+
+  SubnetIds:
+    Type: CommaDelimitedList
+    Description: Comma-separated public subnet IDs (from bootstrap stack output SubnetIds)
+
+  EcsTaskExecutionRoleArn:
+    Type: String
+    Description: ECS task execution role ARN (from bootstrap stack output EcsTaskExecutionRoleArn)
+
+  ApiAcmCertificateArn:
+    Type: String
+    Description: >
+      ACM certificate ARN in us-west-2 covering api.mishmish.ai.
+      Required for HTTPS on the API load balancer.
 
   ApiSecretArn:
     Type: String
@@ -45,7 +59,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: tasks.apprunner.amazonaws.com
+              Service: ecs-tasks.amazonaws.com
             Action: sts:AssumeRole
       Policies:
         - PolicyName: ApiSecretsAccess
@@ -59,58 +73,179 @@ Resources:
                 Resource: !Ref ApiSecretArn
 
   # ============================================================
-  # API Service (App Runner)
+  # API Service (ECS Fargate + ALB)
+  # App Runner does not support WebSocket connections; ALB does.
   # ============================================================
 
-  ApiAutoScalingConfig:
-    Type: AWS::AppRunner::AutoScalingConfiguration
+  AlbSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
     Properties:
-      AutoScalingConfigurationName: prod-api
-      MaxConcurrency: 100
-      MinSize: 1
-      MaxSize: 4
+      GroupDescription: Allow HTTP/HTTPS inbound to API ALB
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Environment
+          Value: production
 
-  ApiService:
-    Type: AWS::AppRunner::Service
+  ApiContainerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow traffic from ALB to API containers on port 8000
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 8000
+          ToPort: 8000
+          SourceSecurityGroupId: !Ref AlbSecurityGroup
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Environment
+          Value: production
+
+  ApiAlb:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: prod-api
+      Scheme: internet-facing
+      Type: application
+      Subnets: !Ref SubnetIds
+      SecurityGroups:
+        - !Ref AlbSecurityGroup
+      Tags:
+        - Key: Environment
+          Value: production
+
+  ApiTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: prod-api
+      VpcId: !Ref VpcId
+      Protocol: HTTP
+      Port: 8000
+      TargetType: ip
+      HealthCheckPath: /health
+      HealthCheckProtocol: HTTP
+      HealthCheckIntervalSeconds: 10
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 5
+      Tags:
+        - Key: Environment
+          Value: production
+
+  ApiAlbListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref ApiAlb
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: !Ref ApiAcmCertificateArn
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref ApiTargetGroup
+
+  ApiHttpRedirectListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref ApiAlb
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            Protocol: HTTPS
+            Port: "443"
+            StatusCode: HTTP_301
+
+  ApiCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: prod-api
+      Tags:
+        - Key: Environment
+          Value: production
+
+  ApiLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /ecs/prod-api
+      RetentionInDays: 14
+
+  ApiTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: prod-api
+      Cpu: "1024"
+      Memory: "2048"
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn: !Ref EcsTaskExecutionRoleArn
+      TaskRoleArn: !GetAtt ApiInstanceRole.Arn
+      ContainerDefinitions:
+        - Name: api
+          Image: !Ref EcrImageUri
+          PortMappings:
+            - ContainerPort: 8000
+          Environment:
+            - Name: PORT
+              Value: "8000"
+          Secrets:
+            - Name: SUPABASE_URL
+              ValueFrom: !Sub "${ApiSecretArn}:SUPABASE_URL::"
+            - Name: SUPABASE_PUBLISHABLE_KEY
+              ValueFrom: !Sub "${ApiSecretArn}:SUPABASE_PUBLISHABLE_KEY::"
+            - Name: SUPABASE_SECRET_KEY
+              ValueFrom: !Sub "${ApiSecretArn}:SUPABASE_SECRET_KEY::"
+            - Name: OPENAI_API_KEY
+              ValueFrom: !Sub "${ApiSecretArn}:OPENAI_API_KEY::"
+            - Name: SONIOX_API_KEY
+              ValueFrom: !Sub "${ApiSecretArn}:SONIOX_API_KEY::"
+            - Name: ELEVEN_API_KEY
+              ValueFrom: !Sub "${ApiSecretArn}:ELEVEN_API_KEY::"
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: /ecs/prod-api
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: api
+      Tags:
+        - Key: Environment
+          Value: production
+
+  ApiEcsService:
+    Type: AWS::ECS::Service
+    DependsOn: ApiAlbListener
     Properties:
       ServiceName: prod-api
-      SourceConfiguration:
-        AuthenticationConfiguration:
-          AccessRoleArn: !Ref AppRunnerEcrRoleArn
-        AutoDeploymentsEnabled: false
-        ImageRepository:
-          ImageIdentifier: !Ref EcrImageUri
-          ImageRepositoryType: ECR
-          ImageConfiguration:
-            Port: "8000"
-            RuntimeEnvironmentVariables:
-              - Name: PORT
-                Value: "8000"
-            RuntimeEnvironmentSecrets:
-              - Name: SUPABASE_URL
-                Value: !Sub "${ApiSecretArn}:SUPABASE_URL::"
-              - Name: SUPABASE_PUBLISHABLE_KEY
-                Value: !Sub "${ApiSecretArn}:SUPABASE_PUBLISHABLE_KEY::"
-              - Name: SUPABASE_SECRET_KEY
-                Value: !Sub "${ApiSecretArn}:SUPABASE_SECRET_KEY::"
-              - Name: OPENAI_API_KEY
-                Value: !Sub "${ApiSecretArn}:OPENAI_API_KEY::"
-              - Name: SONIOX_API_KEY
-                Value: !Sub "${ApiSecretArn}:SONIOX_API_KEY::"
-              - Name: ELEVEN_API_KEY
-                Value: !Sub "${ApiSecretArn}:ELEVEN_API_KEY::"
-      InstanceConfiguration:
-        Cpu: "1024"
-        Memory: "2048"
-        InstanceRoleArn: !GetAtt ApiInstanceRole.Arn
-      AutoScalingConfigurationArn: !GetAtt ApiAutoScalingConfig.AutoScalingConfigurationArn
-      HealthCheckConfiguration:
-        Protocol: HTTP
-        Path: /health
-        Interval: 10
-        Timeout: 5
-        HealthyThreshold: 1
-        UnhealthyThreshold: 5
+      Cluster: !Ref ApiCluster
+      TaskDefinition: !Ref ApiTaskDefinition
+      DesiredCount: 1
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          Subnets: !Ref SubnetIds
+          SecurityGroups:
+            - !Ref ApiContainerSecurityGroup
+      LoadBalancers:
+        - ContainerName: api
+          ContainerPort: 8000
+          TargetGroupArn: !Ref ApiTargetGroup
+      HealthCheckGracePeriodSeconds: 60
       Tags:
         - Key: Environment
           Value: production
@@ -295,8 +430,13 @@ Resources:
 
 Outputs:
   ApiUrl:
-    Description: App Runner API URL
-    Value: !Sub "https://${ApiService.ServiceUrl}"
+    Description: ECS/ALB API URL
+    Value: !Sub "https://${ApiAlb.DNSName}"
+
+  ApiAlbDnsName:
+    Description: >
+      ALB DNS name — point api.mishmish.ai CNAME here
+    Value: !GetAtt ApiAlb.DNSName
 
   WebAppUrl:
     Description: Web app CloudFront URL


### PR DESCRIPTION
## Summary

- App Runner silently terminates WebSocket upgrade requests — the Pipecat voice pipeline needs persistent bidirectional WebSocket connections
- Migrated production API to ECS Fargate + ALB, which transparently passes `Upgrade: websocket` headers
- Bootstrap stack now provisions the VPC, subnets, and ECS task execution role; deploy workflow reads these dynamically instead of from GitHub secrets
- Preview environments remain on App Runner (WebSockets not critical for PR previews)

## Changes

**Bootstrap stack** (`infra/bootstrap/template.yaml`):
- Added VPC (10.0.0.0/16), 2 public subnets, Internet Gateway, route table
- Added `EcsTaskExecutionRole` (ECR pull + CloudWatch Logs + Secrets Manager read)
- Added ECS, ALB, EC2, IAM, CloudWatch Logs permissions to `GitHubActionsRole`
- New outputs: `VpcId`, `SubnetIds`, `EcsTaskExecutionRoleArn`

**Prod stack** (`infra/prod/template.yaml`):
- Replaced App Runner service with ECS Fargate cluster + ALB
- ALB with HTTPS (port 443) listener + HTTP→HTTPS redirect (port 80)
- Secrets injected via ECS `ValueFrom` (Secrets Manager) rather than env vars
- New `ApiAlbDnsName` output for CNAME setup instructions

**Deploy workflow** (`.github/workflows/deploy-prod.yml`):
- Reads `VpcId`, `SubnetIds`, `EcsTaskExecutionRoleArn` from bootstrap stack at deploy time
- Passes `ApiAcmCertificateArn` (us-west-2 cert for `api.mishmish.ai`) to prod stack

## Prerequisites (already done)
- [x] Bootstrap stack deployed with new VPC + ECS resources
- [x] ACM certificate issued for `api.mishmish.ai` in us-west-2
- [x] `API_ACM_CERTIFICATE_ARN` added as GitHub secret

## Post-merge
After the prod deploy completes, point `api.mishmish.ai` CNAME to the ALB DNS name shown in the workflow step summary.

## Test plan
- [ ] Merge to main triggers `deploy-prod.yml`
- [ ] ECS service reaches RUNNING state
- [ ] Health check at `/health` returns 200
- [ ] WebSocket connection to `/pipecat/session/{id}` succeeds
- [ ] Update `api.mishmish.ai` CNAME to new ALB DNS name

🤖 Generated with [Claude Code](https://claude.com/claude-code)