### PR TITLE
fix(infra): add missing IAM permissions and auto-recover stuck stacks

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -100,6 +100,12 @@ jobs:
             aws cloudformation wait stack-rollback-complete --stack-name "$STACK_NAME"
             STATUS="ROLLBACK_COMPLETE"
           fi
+          if [ "$STATUS" = "UPDATE_ROLLBACK_FAILED" ]; then
+            echo "Stack $STACK_NAME is stuck in UPDATE_ROLLBACK_FAILED, attempting continue-update-rollback..."
+            aws cloudformation continue-update-rollback --stack-name "$STACK_NAME"
+            aws cloudformation wait stack-rollback-complete --stack-name "$STACK_NAME"
+            STATUS="UPDATE_ROLLBACK_COMPLETE"
+          fi
           if [ "$STATUS" = "ROLLBACK_COMPLETE" ] || [ "$STATUS" = "DELETE_FAILED" ] || [ "$STATUS" = "REVIEW_IN_PROGRESS" ]; then
             echo "Stack $STACK_NAME is in $STATUS state, deleting before redeploy..."
             aws cloudformation delete-stack --stack-name "$STACK_NAME"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -167,6 +167,12 @@ jobs:
             aws cloudformation wait stack-rollback-complete --stack-name "$STACK_NAME"
             STATUS="ROLLBACK_COMPLETE"
           fi
+          if [ "$STATUS" = "UPDATE_ROLLBACK_FAILED" ]; then
+            echo "Stack $STACK_NAME is stuck in UPDATE_ROLLBACK_FAILED, attempting continue-update-rollback..."
+            aws cloudformation continue-update-rollback --stack-name "$STACK_NAME"
+            aws cloudformation wait stack-rollback-complete --stack-name "$STACK_NAME"
+            STATUS="UPDATE_ROLLBACK_COMPLETE"
+          fi
           if [ "$STATUS" = "ROLLBACK_COMPLETE" ] || [ "$STATUS" = "DELETE_FAILED" ]; then
             echo "Stack $STACK_NAME is in $STATUS state, deleting before redeploy..."
             aws cloudformation delete-stack --stack-name "$STACK_NAME"

--- a/infra/bootstrap/template.yaml
+++ b/infra/bootstrap/template.yaml
@@ -303,6 +303,7 @@ Resources:
                   - cloudformation:DescribeChangeSet
                   - cloudformation:ExecuteChangeSet
                   - cloudformation:DeleteChangeSet
+                  - cloudformation:ContinueUpdateRollback
                 Resource:
                   - !Sub "arn:aws:cloudformation:*:${AWS::AccountId}:stack/preview-pr-*/*"
                   - !Sub "arn:aws:cloudformation:*:${AWS::AccountId}:stack/arabic-voice-agent-prod/*"
@@ -380,6 +381,7 @@ Resources:
                   - iam:CreateRole
                   - iam:DeleteRole
                   - iam:GetRole
+                  - iam:UpdateAssumeRolePolicy
                   - iam:PutRolePolicy
                   - iam:DeleteRolePolicy
                   - iam:GetRolePolicy


### PR DESCRIPTION
## Summary
- Added `iam:UpdateAssumeRolePolicy` to the GitHub Actions deployer role — this was blocking creation of the ECS task role (`prod-api-instance-role`) during the Fargate migration
- Added `cloudformation:ContinueUpdateRollback` permission so the deployer can self-heal stuck stacks
- Both `deploy-prod.yml` and `preview-deploy.yml` now auto-recover from `UPDATE_ROLLBACK_FAILED` state before retrying

## Also done (outside this PR)
- Unstuck the prod stack (`continue-update-rollback` → `UPDATE_ROLLBACK_COMPLETE`)
- Deployed updated bootstrap template to AWS (IAM permissions are already live)
- Added `API_SECRET_ARN` GitHub repo secret

## Test plan
- [ ] Merge and let `deploy-prod.yml` trigger on push to main
- [ ] Verify CloudFormation stack reaches `CREATE_COMPLETE` / `UPDATE_COMPLETE`
- [ ] Confirm ECS service starts healthy behind ALB

🤖 Generated with [Claude Code](https://claude.com/claude-code)