### PR TITLE
fix(infra): hardcode Caddy version to fix Fn::Sub conflict

### DIFF
--- a/infra/preview/template.yaml
+++ b/infra/preview/template.yaml
@@ -90,8 +90,7 @@ Resources:
           systemctl start docker
 
           # Install Caddy (direct binary — AL2023 has no RPM package)
-          CADDY_VERSION="2.9.1"
-          curl -sL "https://github.com/caddyserver/caddy/releases/download/v$${CADDY_VERSION}/caddy_$${CADDY_VERSION}_linux_amd64.tar.gz" -o /tmp/caddy.tar.gz
+          curl -sL "https://github.com/caddyserver/caddy/releases/download/v2.9.1/caddy_2.9.1_linux_amd64.tar.gz" -o /tmp/caddy.tar.gz
           tar xzf /tmp/caddy.tar.gz -C /usr/bin caddy
           chmod +x /usr/bin/caddy
           rm /tmp/caddy.tar.gz

--- a/infra/prod/template.yaml
+++ b/infra/prod/template.yaml
@@ -111,8 +111,7 @@ Resources:
           systemctl start docker
 
           # Install Caddy (direct binary — AL2023 has no RPM package)
-          CADDY_VERSION="2.9.1"
-          curl -sL "https://github.com/caddyserver/caddy/releases/download/v$${CADDY_VERSION}/caddy_$${CADDY_VERSION}_linux_amd64.tar.gz" -o /tmp/caddy.tar.gz
+          curl -sL "https://github.com/caddyserver/caddy/releases/download/v2.9.1/caddy_2.9.1_linux_amd64.tar.gz" -o /tmp/caddy.tar.gz
           tar xzf /tmp/caddy.tar.gz -C /usr/bin caddy
           chmod +x /usr/bin/caddy
           rm /tmp/caddy.tar.gz


### PR DESCRIPTION
## Summary
- Hardcode Caddy version `2.9.1` directly in UserData URLs instead of using a shell variable
- `Fn::Sub` in CloudFormation interprets `${CADDY_VERSION}` as a resource reference, causing template validation failure

## Context
Discovered during deployment of the preview EC2 infrastructure (from PR #64). The prod and preview templates both had this issue.

## Test plan
- [x] Prod API healthy at `https://api.mishmish.ai/health`
- [ ] Preview infra deploy workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)