### PR TITLE
feat(config): add PostHog analytics integration

### DIFF
--- a/.claude/skills/posthog.md
+++ b/.claude/skills/posthog.md
@@ -1,0 +1,399 @@
+---
+name: posthog
+description: >
+  Use this skill for any PostHog analytics task. Triggers when the user mentions
+  PostHog, product analytics, feature flags, A/B tests, experiments, session recordings,
+  event tracking, funnels, cohorts, dashboards, or asks to "set up analytics",
+  "add tracking", "manage feature flags", etc. Also trigger for "/posthog". Covers both
+  PostHog CLI operations and PostHog API/SDK integration code.
+user-invocable: true
+allowed-tools: Read, Write, Bash, Glob, Grep, Edit, AskUserQuestion, WebFetch
+argument-hint: "[command or task description]"
+---
+
+# PostHog CLI & Analytics Management
+
+You are an expert at using the PostHog CLI and integrating PostHog analytics into applications. Use this skill to help with all PostHog-related tasks.
+
+## Step 1: Ensure PostHog CLI is available
+
+Check if `posthog` is installed:
+
+```bash
+which posthog
+```
+
+If not found, install it:
+
+- **macOS**: `brew install posthog-cli` — if the Homebrew formula is unavailable, fall back to the pip method below.
+- **pip (any platform)**:
+  ```bash
+  pip install posthog-cli
+  ```
+- **npm (any platform)**:
+  ```bash
+  npm install -g posthog
+  ```
+
+If none of these install methods work, check the PostHog docs for the latest installation instructions:
+```bash
+# Check if there's a standalone binary or updated install method
+open https://posthog.com/docs/cli
+```
+
+After installation, verify it works:
+```bash
+posthog --version
+```
+
+## Step 2: Resolve the project's PostHog configuration
+
+This skill uses a **per-project PostHog config** so you never accidentally operate on the wrong PostHog project.
+
+### How it works
+
+1. Check for a `.posthog-project` file in the repo root. This file contains the PostHog **project API key** and **host** (no secrets — the `phc_` key is public, same as what ships in browser JS):
+   ```
+   POSTHOG_CLI_PROJECT_API_KEY=phc_xxxxx
+   POSTHOG_CLI_HOST=https://us.i.posthog.com
+   ```
+2. If `.posthog-project` exists, read the values and use them for all PostHog CLI and API commands.
+3. If `.posthog-project` does NOT exist, ask the user:
+   - "What PostHog project should this repo use? I need:"
+   - "1. Your PostHog **project API key** (starts with `phc_`) — found in Project Settings → Project API Key"
+   - "2. Your PostHog **host** (e.g., `https://us.i.posthog.com` or `https://eu.i.posthog.com` or a self-hosted URL)"
+   - Once they provide these, create `.posthog-project` with those values.
+
+`.posthog-project` contains **no secrets** (the `phc_` key is a public project key) and is committed to the repo — all developers share the same project config.
+
+### Authenticating the CLI
+
+Authentication is handled via the PostHog CLI's own login flow, **not** stored in `.posthog-project`. Each developer authenticates once on their machine.
+
+```bash
+# Authenticate with PostHog (opens browser for OAuth)
+posthog login
+
+# Or authenticate with a personal API key
+posthog login --personal-api-key=phx_xxxxx
+```
+
+If the CLI doesn't support `login`, the user needs a **personal API key** (starts with `phx_`). Guide them to create one:
+- Go to PostHog → Settings (gear icon) → User → Personal API Keys → Create key
+- Then export it for the current shell session:
+  ```bash
+  export POSTHOG_PERSONAL_API_KEY=phx_xxxxx
+  ```
+
+### Verifying auth works
+
+```bash
+# Test that auth + project config work together
+curl -s -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  "$(grep POSTHOG_CLI_HOST .posthog-project | cut -d= -f2)/api/projects/@current/" | python3 -m json.tool
+```
+
+### Key rules
+
+- **`.posthog-project` stores only non-secret project identifiers** (project ID and host). It is safe to commit.
+- **Secrets (personal API keys) are never stored in `.posthog-project`**. They come from CLI auth or environment variables.
+- **Always read `.posthog-project`** at the start to determine `POSTHOG_CLI_HOST` and `POSTHOG_CLI_PROJECT_API_KEY` for API calls.
+- When using the API directly, read the host and project ID from `.posthog-project` and use them to scope requests (e.g., `$POSTHOG_CLI_HOST/api/projects/$POSTHOG_CLI_PROJECT_API_KEY/...`).
+
+## Step 3: Understand the task
+
+The user's input is in `$ARGUMENTS`. Common categories:
+
+### Feature Flags
+```bash
+# List feature flags
+posthog feature-flags list
+
+# Create a feature flag
+posthog feature-flags create --key=new-onboarding --description="New user onboarding flow"
+
+# Toggle a feature flag
+posthog feature-flags enable --key=new-onboarding
+posthog feature-flags disable --key=new-onboarding
+
+# Check flag status
+posthog feature-flags get --key=new-onboarding
+```
+
+If the CLI doesn't support these commands, use the PostHog API directly (reading host from `.posthog-project`):
+```bash
+POSTHOG_CLI_HOST=$(grep POSTHOG_CLI_HOST .posthog-project | cut -d= -f2)
+POSTHOG_CLI_PROJECT_API_KEY=$(grep POSTHOG_CLI_PROJECT_API_KEY .posthog-project | cut -d= -f2)
+
+# List feature flags via API
+curl -s -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  "$POSTHOG_CLI_HOST/api/projects/$POSTHOG_CLI_PROJECT_API_KEY/feature_flags/" | python3 -m json.tool
+
+# Create a feature flag via API
+curl -s -X POST -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$POSTHOG_CLI_HOST/api/projects/$POSTHOG_CLI_PROJECT_API_KEY/feature_flags/" \
+  -d '{"key": "new-onboarding", "name": "New onboarding flow", "filters": {"groups": [{"rollout_percentage": 0}]}}'
+
+# Toggle a feature flag via API
+curl -s -X PATCH -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$POSTHOG_CLI_HOST/api/projects/$POSTHOG_CLI_PROJECT_API_KEY/feature_flags/<FLAG_ID>/" \
+  -d '{"active": true}'
+```
+
+### Events & Analytics
+```bash
+POSTHOG_CLI_HOST=$(grep POSTHOG_CLI_HOST .posthog-project | cut -d= -f2)
+POSTHOG_CLI_PROJECT_API_KEY=$(grep POSTHOG_CLI_PROJECT_API_KEY .posthog-project | cut -d= -f2)
+
+# Query events via API
+curl -s -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  "$POSTHOG_CLI_HOST/api/projects/$POSTHOG_CLI_PROJECT_API_KEY/events/?event=page_view&limit=10" | python3 -m json.tool
+
+# Query insights (funnels, trends, etc.)
+curl -s -X POST -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$POSTHOG_CLI_HOST/api/projects/$POSTHOG_CLI_PROJECT_API_KEY/insights/trend/" \
+  -d '{"events": [{"id": "pageview"}], "date_from": "-7d"}'
+```
+
+### Cohorts
+```bash
+# List cohorts
+curl -s -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  "$POSTHOG_CLI_HOST/api/projects/$POSTHOG_CLI_PROJECT_API_KEY/cohorts/" | python3 -m json.tool
+
+# Create a cohort
+curl -s -X POST -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$POSTHOG_CLI_HOST/api/projects/$POSTHOG_CLI_PROJECT_API_KEY/cohorts/" \
+  -d '{"name": "Power users", "groups": [{"properties": [{"key": "session_count", "value": 10, "type": "person", "operator": "gt"}]}]}'
+```
+
+### Annotations
+```bash
+# Create an annotation (e.g., marking a deploy)
+curl -s -X POST -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  "$POSTHOG_CLI_HOST/api/projects/$POSTHOG_CLI_PROJECT_API_KEY/annotations/" \
+  -d '{"content": "Deployed v1.2.0", "date_marker": "2024-01-15T12:00:00Z", "scope": "project"}'
+```
+
+### Persons
+```bash
+# Search for a person
+curl -s -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  "$POSTHOG_CLI_HOST/api/projects/$POSTHOG_CLI_PROJECT_API_KEY/persons/?search=user@example.com" | python3 -m json.tool
+
+# Get person details
+curl -s -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  "$POSTHOG_CLI_HOST/api/projects/$POSTHOG_CLI_PROJECT_API_KEY/persons/<PERSON_ID>/" | python3 -m json.tool
+```
+
+### Dashboards
+```bash
+# List dashboards
+curl -s -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  "$POSTHOG_CLI_HOST/api/projects/$POSTHOG_CLI_PROJECT_API_KEY/dashboards/" | python3 -m json.tool
+
+# Get a specific dashboard
+curl -s -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  "$POSTHOG_CLI_HOST/api/projects/$POSTHOG_CLI_PROJECT_API_KEY/dashboards/<DASHBOARD_ID>/" | python3 -m json.tool
+```
+
+## Step 4: Integrating PostHog into the codebase
+
+When the user wants to add PostHog support to the application code, follow these patterns:
+
+### Backend (Python/FastAPI — web-api)
+
+**Dependencies**: Add `posthog` to `pyproject.toml` dependencies.
+
+```bash
+cd web-api && uv add posthog
+```
+
+**Environment variables needed**:
+- `POSTHOG_API_KEY` — Project API key (phc_...) — used by the SDK to send events
+- `POSTHOG_HOST` — PostHog instance host (e.g., `https://us.i.posthog.com`)
+
+**Initialization** (`services/posthog_client.py`):
+```python
+import posthog
+from config import settings
+
+posthog.api_key = settings.POSTHOG_API_KEY
+posthog.host = settings.POSTHOG_HOST
+
+# Disable in tests
+posthog.disabled = settings.TESTING
+```
+
+**Event tracking**:
+```python
+import posthog
+
+# Track an event
+posthog.capture(
+    distinct_id=user_id,
+    event="lesson_completed",
+    properties={
+        "lesson_id": lesson_id,
+        "language": "arabic",
+        "duration_seconds": duration,
+    },
+)
+
+# Identify a user
+posthog.identify(
+    distinct_id=user_id,
+    properties={
+        "email": user.email,
+        "name": user.name,
+        "plan": user.subscription_tier,
+    },
+)
+```
+
+**Feature flags (server-side)**:
+```python
+import posthog
+
+# Check a feature flag
+if posthog.feature_enabled("new-onboarding", distinct_id=user_id):
+    # New onboarding flow
+    ...
+
+# Get feature flag payload
+payload = posthog.get_feature_flag_payload("new-onboarding", distinct_id=user_id)
+```
+
+**Shutdown** — call `posthog.shutdown()` on app shutdown to flush events:
+```python
+@app.on_event("shutdown")
+def shutdown_posthog():
+    posthog.shutdown()
+```
+
+### Frontend (React — web-app)
+
+**Dependencies**:
+```bash
+cd web-app && npm install posthog-js
+```
+
+**Initialization** (`src/posthog.ts`):
+```typescript
+import posthog from "posthog-js";
+
+posthog.init(import.meta.env.VITE_POSTHOG_KEY, {
+  api_host: import.meta.env.VITE_POSTHOG_HOST || "https://us.i.posthog.com",
+  person_profiles: "identified_only",
+  capture_pageview: true,
+  capture_pageleave: true,
+});
+
+export default posthog;
+```
+
+**React provider** (`src/main.tsx` or `src/App.tsx`):
+```typescript
+import { PostHogProvider } from "posthog-js/react";
+import posthog from "./posthog";
+
+<PostHogProvider client={posthog}>
+  <App />
+</PostHogProvider>
+```
+
+**Usage in components**:
+```typescript
+import { usePostHog, useFeatureFlagEnabled } from "posthog-js/react";
+
+function MyComponent() {
+  const posthog = usePostHog();
+  const showNewFeature = useFeatureFlagEnabled("new-feature");
+
+  const handleClick = () => {
+    posthog.capture("button_clicked", { button_name: "start_lesson" });
+  };
+
+  return showNewFeature ? <NewFeature /> : <OldFeature />;
+}
+```
+
+**Identify users after login**:
+```typescript
+posthog.identify(user.id, {
+  email: user.email,
+  name: user.name,
+});
+```
+
+**Reset on logout**:
+```typescript
+posthog.reset();
+```
+
+### Flutter (flutter-app)
+
+**Dependencies** (`pubspec.yaml`):
+```yaml
+dependencies:
+  posthog_flutter: ^4.0.0
+```
+
+**Initialization**:
+```dart
+import 'package:posthog_flutter/posthog_flutter.dart';
+
+await Posthog().setup(
+  PosthogConfig(apiKey: 'phc_xxxxx')
+    ..host = 'https://us.i.posthog.com',
+);
+```
+
+**Usage**:
+```dart
+// Capture event
+await Posthog().capture(
+  eventName: 'lesson_started',
+  properties: {'lesson_id': lessonId},
+);
+
+// Identify user
+await Posthog().identify(
+  userId: user.id,
+  userProperties: {'email': user.email},
+);
+
+// Feature flags
+final enabled = await Posthog().isFeatureEnabled('new-onboarding');
+```
+
+## Step 5: Common analytics patterns for this project
+
+Events worth tracking for the Arabic Voice Agent:
+
+| Event | Properties | When |
+|-------|-----------|------|
+| `session_started` | `session_id`, `language`, `dialect` | User starts a voice session |
+| `session_ended` | `session_id`, `duration_seconds`, `message_count` | Voice session ends |
+| `message_sent` | `session_id`, `language`, `message_type` | User sends a message |
+| `dialect_changed` | `from_dialect`, `to_dialect` | User switches dialect |
+| `lesson_completed` | `lesson_id`, `score`, `duration` | User completes a lesson |
+| `signup_completed` | `method` (google, email) | User creates account |
+| `subscription_started` | `plan`, `price` | User subscribes |
+
+## Tips
+
+- **Always read `.posthog-project`** at the start to get `POSTHOG_CLI_HOST` and `POSTHOG_CLI_PROJECT_API_KEY`
+- `.posthog-project` is committed to the repo — it contains no secrets, just the public project API key and host
+- **Secrets (personal API keys) come from CLI auth or `$POSTHOG_PERSONAL_API_KEY` env var** — never store them in `.posthog-project`
+- **Application SDK keys** (`phc_...`) go in `.env` files per package — never hardcode them
+- Use `posthog.disabled = True` in test environments to avoid polluting analytics
+- Use `posthog.shutdown()` on app shutdown to flush any pending events
+- The PostHog CLI is relatively new and may not support all operations — fall back to the REST API via `curl` when needed
+- Use `person_profiles: "identified_only"` on the frontend to avoid creating anonymous person profiles unnecessarily
+- Group analytics by `language` and `dialect` properties to understand usage across Arabic dialects

--- a/.posthog-project
+++ b/.posthog-project
@@ -1,0 +1,2 @@
+POSTHOG_CLI_PROJECT_API_KEY=phc_1ZBbhKOZcsCo52DvnYzl1ie38hPfPaLrUCxdymVhDIQ
+POSTHOG_CLI_HOST=https://us.i.posthog.com

--- a/web-api/.env.example
+++ b/web-api/.env.example
@@ -16,6 +16,10 @@ ELEVEN_API_KEY=
 SONIOX_API_KEY=
 WEBHOOK_BASE_URL=http://localhost:8000
 
+# PostHog Analytics (optional)
+POSTHOG_API_KEY=phc_1ZBbhKOZcsCo52DvnYzl1ie38hPfPaLrUCxdymVhDIQ
+POSTHOG_HOST=https://us.i.posthog.com
+
 # Server Configuration (optional)
 HOST=0.0.0.0
 PORT=8000

--- a/web-api/main.py
+++ b/web-api/main.py
@@ -23,6 +23,9 @@ env_path = Path(__file__).parent / ".env"
 load_dotenv(dotenv_path=env_path, override=True)
 
 
+from services import posthog_service  # noqa: E402 — must import after dotenv
+
+
 app = FastAPI(
     title="mishmish.ai API",
     description="Backend API for the mishmish.ai application",
@@ -45,6 +48,12 @@ app.include_router(realtime_pipecat_router)
 app.include_router(content_router)
 app.include_router(webhooks_router)
 app.include_router(admin_router)
+
+
+@app.on_event("shutdown")
+def shutdown_posthog():
+    """Flush pending PostHog events on shutdown."""
+    posthog_service.shutdown()
 
 
 @app.get("/")

--- a/web-api/pyproject.toml
+++ b/web-api/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "httpx>=0.28.1",
     "supabase>=2.24.0",
     "debugpy>=1.8.0",
+    "posthog>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/web-api/services/posthog_service.py
+++ b/web-api/services/posthog_service.py
@@ -1,0 +1,26 @@
+"""PostHog analytics service."""
+
+import os
+
+import posthog
+
+
+# Initialize PostHog — disabled gracefully if no API key is set
+_api_key = os.getenv("POSTHOG_API_KEY")
+_host = os.getenv("POSTHOG_HOST", "https://us.i.posthog.com")
+
+if _api_key:
+    posthog.api_key = _api_key
+    posthog.host = _host
+else:
+    posthog.disabled = True
+
+
+def capture(distinct_id: str, event: str, properties: dict | None = None) -> None:
+    """Capture an analytics event."""
+    posthog.capture(distinct_id=distinct_id, event=event, properties=properties or {})
+
+
+def shutdown() -> None:
+    """Flush pending events. Call on app shutdown."""
+    posthog.shutdown()

--- a/web-api/services/session_service.py
+++ b/web-api/services/session_service.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional
 from services.agent_session import AgentSession
 from services.supabase_client import get_supabase_user_client, get_supabase_admin_client
 from services.context_service import create_context, delete_context
+from services import posthog_service
 
 # In-memory session storage indexed by session_id
 _sessions: Dict[str, AgentSession] = {}
@@ -35,6 +36,14 @@ def create_session(user_access_token: str) -> str:
         session_id=session_id,
         user_id=session_id,  # Using session_id as user_id for now
         user_name="User"     # Placeholder user name
+    )
+
+    # Track session creation
+    user = getattr(session, "user", None)
+    posthog_service.capture(
+        distinct_id=user.id if user else session_id,
+        event="session_started",
+        properties={"session_id": session_id},
     )
 
     return session_id

--- a/web-api/uv.lock
+++ b/web-api/uv.lock
@@ -274,6 +274,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1774,6 +1783,23 @@ wheels = [
 ]
 
 [[package]]
+name = "posthog"
+version = "7.9.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "six" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/a7/2865487853061fbd62383492237b546d2d8f7c1846272350d2b9e14138cd/posthog-7.9.12.tar.gz", hash = "sha256:ebabf2eb2e1c1fbf22b0759df4644623fa43cc6c9dcbe9fd429b7937d14251ec", size = 176828, upload-time = "2026-03-12T09:01:15.184Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/a9/7a803aed5a5649cf78ea7b31e90d0080181ba21f739243e1741a1e607f1f/posthog-7.9.12-py3-none-any.whl", hash = "sha256:7175bd1698a566bfea98a016c64e3456399f8046aeeca8f1d04ae5bf6c5a38d0", size = 202469, upload-time = "2026-03-12T09:01:13.38Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2180,6 +2206,18 @@ dependencies = [
     { name = "watchdog" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/47/ab65fc1d682befc318c439940f81a0de1026048479f732e84fe714cd69c0/pytest-watch-4.2.0.tar.gz", hash = "sha256:06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9", size = 16340, upload-time = "2018-05-20T19:52:16.194Z" }
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
 
 [[package]]
 name = "python-dotenv"
@@ -2731,6 +2769,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3225,6 +3272,7 @@ dependencies = [
     { name = "httpx" },
     { name = "openai-agents" },
     { name = "pipecat-ai", extra = ["deepgram", "elevenlabs", "openai", "silero", "websocket"] },
+    { name = "posthog" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "supabase" },
@@ -3252,6 +3300,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "openai-agents", specifier = ">=0.4.1" },
     { name = "pipecat-ai", extras = ["openai", "elevenlabs", "deepgram", "websocket", "silero"], specifier = ">=0.0.100" },
+    { name = "posthog", specifier = ">=3.0.0" },
     { name = "pydantic", specifier = ">=2.10.3" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },

--- a/web-app/.env.example
+++ b/web-app/.env.example
@@ -13,3 +13,7 @@ VITE_API_URL=http://localhost:8000
 # For local development, use:
 VITE_SUPABASE_URL=http://127.0.0.1:54321
 VITE_SUPABASE_PUBLISHABLE_KEY=your-publishable-key-here
+
+# PostHog Analytics (optional — leave blank to disable)
+VITE_POSTHOG_KEY=phc_1ZBbhKOZcsCo52DvnYzl1ie38hPfPaLrUCxdymVhDIQ
+VITE_POSTHOG_HOST=https://us.i.posthog.com

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -17,6 +17,7 @@
         "@tanstack/react-query": "^5.90.18",
         "axios": "^1.13.2",
         "motion": "^12.26.2",
+        "posthog-js": "^1.362.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-icons": "^5.5.0",
@@ -1480,6 +1481,252 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.208.0",
+        "@opentelemetry/otlp-transformer": "0.208.0",
+        "@opentelemetry/sdk-logs": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.208.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
+      "integrity": "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pandacss/is-valid-prop": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@pandacss/is-valid-prop/-/is-valid-prop-1.7.0.tgz",
@@ -1547,6 +1794,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@posthog/core": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.24.0.tgz",
+      "integrity": "sha512-Wkp9mgNfgdf6+G4C1VMKakm2RXKQFf4bb5/CPQRAjpqv9l6BY36zZrD1+X5Y2XIAzZqbMKRxsDu3V1r6uKu7/A==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.362.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.362.0.tgz",
+      "integrity": "sha512-15wOI5uulkfzpkSQKVN4atZecAla2Hxr8IBIB8islqDvqY+42vbR+tMeDKMman9+FUoAqMzE0OnB8VIbM1QY0w==",
+      "license": "MIT"
+    },
     "node_modules/@protobuf-ts/plugin": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin/-/plugin-2.11.1.tgz",
@@ -1601,6 +1863,70 @@
       "dependencies": {
         "@protobuf-ts/runtime": "^2.11.1"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
@@ -2589,6 +2915,13 @@
       "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -4613,6 +4946,17 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -4642,7 +4986,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4793,6 +5136,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5256,6 +5608,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -5845,7 +6203,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -6365,6 +6722,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -6751,7 +7114,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6937,6 +7299,37 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.362.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.362.0.tgz",
+      "integrity": "sha512-qPHkAk9G19xVDAQLoQ1FOLNE9BBq+FDePhkOevbdUQcFJVNHVc+j7E/ndQ+olGnDuiSMdgAb5c6yGk7PD9Z0ug==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
+        "@posthog/core": "1.24.0",
+        "@posthog/types": "1.362.0",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
+      "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6977,6 +7370,30 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-compare": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
@@ -7007,6 +7424,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -7346,7 +7769,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7359,7 +7781,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8286,6 +8707,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
+      "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
@@ -8297,7 +8724,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -21,6 +21,7 @@
     "@tanstack/react-query": "^5.90.18",
     "axios": "^1.13.2",
     "motion": "^12.26.2",
+    "posthog-js": "^1.362.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-icons": "^5.5.0",

--- a/web-app/src/context/AuthContext.tsx
+++ b/web-app/src/context/AuthContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 import type { User, Session, SupabaseClient } from '@supabase/supabase-js';
+import posthog from '@/posthog';
 import { useSupabaseOptional } from './SupabaseContext';
 import { isAnonymousUser } from '@/lib/auth';
 
@@ -74,6 +75,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       });
       setSession(session);
       setUser(session?.user ?? null);
+
+      // Sync PostHog identity with Supabase auth state
+      const u = session?.user;
+      if (_event === 'SIGNED_OUT') {
+        posthog.reset();
+      } else if (u && !u.is_anonymous) {
+        posthog.identify(u.id, { email: u.email });
+      }
     });
 
     return () => subscription.unsubscribe();

--- a/web-app/src/main.tsx
+++ b/web-app/src/main.tsx
@@ -1,9 +1,11 @@
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { PostHogProvider } from 'posthog-js/react'
 import { SupabaseProvider } from './context/SupabaseContext'
 import { AuthProvider } from './context/AuthContext'
 import { Provider } from './components/ui/provider'
+import posthog from './posthog'
 import './typography.css'
 import './index.css'
 import App from './App.tsx'
@@ -22,15 +24,17 @@ const queryClient = new QueryClient({
 })
 
 createRoot(document.getElementById('root')!).render(
-  <QueryClientProvider client={queryClient}>
-    <Provider>
-      <SupabaseProvider>
-        <AuthProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
-        </AuthProvider>
-      </SupabaseProvider>
-    </Provider>
-  </QueryClientProvider>,
+  <PostHogProvider client={posthog}>
+    <QueryClientProvider client={queryClient}>
+      <Provider>
+        <SupabaseProvider>
+          <AuthProvider>
+            <BrowserRouter>
+              <App />
+            </BrowserRouter>
+          </AuthProvider>
+        </SupabaseProvider>
+      </Provider>
+    </QueryClientProvider>
+  </PostHogProvider>,
 )

--- a/web-app/src/posthog.ts
+++ b/web-app/src/posthog.ts
@@ -1,0 +1,15 @@
+import posthog from "posthog-js";
+
+const apiKey = import.meta.env.VITE_POSTHOG_KEY;
+const host = import.meta.env.VITE_POSTHOG_HOST || "https://us.i.posthog.com";
+
+if (apiKey) {
+  posthog.init(apiKey, {
+    api_host: host,
+    person_profiles: "identified_only",
+    capture_pageview: true,
+    capture_pageleave: true,
+  });
+}
+
+export default posthog;


### PR DESCRIPTION
## Summary
- Add PostHog JS SDK to **web-app** with `PostHogProvider`, user identify/reset on auth state changes, and graceful no-op when unconfigured
- Add PostHog Python SDK to **web-api** with a `posthog_service` wrapper and `session_started` event tracking in `session_service`
- Add `.posthog-project` committed config (public project API key + host only, no secrets)
- Add Claude Code skill (`.claude/skills/posthog.md`) for PostHog CLI usage, installation, and API fallback patterns
- Update `.env.example` files with PostHog configuration

## Test plan
- [ ] Verify `npm run build` passes in web-app (TypeScript + Vite)
- [ ] Verify web-api starts without errors with PostHog env vars set
- [ ] Verify PostHog events appear in PostHog dashboard after a voice session
- [ ] Verify app works correctly when PostHog env vars are absent (graceful no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)