### PR TITLE
feat: add Arabizi transliteration for voice chat transcripts

### DIFF
--- a/web-api/services/pipecat_service.py
+++ b/web-api/services/pipecat_service.py
@@ -29,6 +29,7 @@ from pipecat.processors.frameworks.rtvi import (
 )
 
 from .context_service import get_context
+from .scaffolding_service import generate_transliterated_text
 from .session_service import get_session
 from .transcript_service import create_transcript_message
 
@@ -60,11 +61,12 @@ class TTSTranscriptProcessor(FrameProcessor):
                 sentence_text = " ".join(self._current_sentence)
                 logger.info(f"TTS sentence complete: {sentence_text}")
                 try:
+                    transliterated = await generate_transliterated_text(sentence_text)
                     await create_transcript_message(
                         session_id=self._session_id,
                         message_source="tutor",
                         message_kind="transcript",
-                        message_text=sentence_text,
+                        message_text=transliterated,
                         message_text_canonical=sentence_text,
                     )
                 except Exception as e:

--- a/web-api/services/scaffolding_service.py
+++ b/web-api/services/scaffolding_service.py
@@ -1,6 +1,8 @@
 """Scaffolding service for generating learner-facing display text from canonical Arabic.
 
-Translates Arabic into English, keeping familiar words inline as Arabizi.
+Two modes:
+- Scaffolded text: Translates Arabic into English, keeping familiar words as Arabizi.
+- Transliterated text: Pure Arabizi romanization of Arabic (no translation).
 """
 
 import os
@@ -105,3 +107,56 @@ async def generate_scaffolded_text(
         logger.error(f"Failed to generate scaffolded text: {e}")
         # Fall back to the original Arabic text if the LLM call fails
         return arabic_text
+
+
+TRANSLITERATION_PROMPT = """\
+You are an Arabizi transliteration tool. Transliterate the following text so that \
+all Arabic script is written using the English alphabet (Arabizi). Do NOT translate — \
+keep the same Arabic words, just write them with Latin letters.
+
+Rules:
+- Transliterate every Arabic word into Arabizi (romanized Arabic).
+- Use common Arabizi conventions: 3 for ع, 7 for ح, 2 for ء or ق, 5 for خ, 8 for غ, 6 for ط, 9 for ص.
+- Preserve any English words already in the text exactly as they are.
+- The output must contain ZERO Arabic script.
+- Do NOT translate any Arabic words into English — only romanize them.
+- Do NOT add explanations, notes, or extra text.
+- Return ONLY the transliterated text, nothing else.
+
+Text:
+{text}"""
+
+
+async def generate_transliterated_text(text: str) -> str:
+    """
+    Transliterate Arabic script to Arabizi (romanized Arabic).
+
+    Unlike scaffolded text, this does no translation — it purely romanizes
+    Arabic words using the English alphabet. Any English words in the input
+    are preserved as-is.
+
+    Args:
+        text: Text that may contain Arabic script.
+
+    Returns:
+        The same text with all Arabic script replaced by Arabizi.
+    """
+    try:
+        client = _get_client()
+        response = await client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": TRANSLITERATION_PROMPT.format(text=text)}],
+            temperature=0.2,
+            max_tokens=500,
+        )
+
+        result = response.choices[0].message.content
+        if result:
+            return result.strip()
+
+        logger.warning("Empty response from transliteration LLM call, falling back to original text")
+        return text
+
+    except Exception as e:
+        logger.error(f"Failed to generate transliterated text: {e}")
+        return text


### PR DESCRIPTION
## Changes

- **scaffolding_service.py**: Added new `generate_transliterated_text()` function that converts Arabic script to Arabizi (romanized Arabic) without translation. Includes a specialized prompt that uses common Arabizi conventions (3 for ع, 7 for ح, etc.) and preserves any existing English words.

- **pipecat_service.py**: Updated `TTSTranscriptProcessor` to call the new transliteration function on TTS sentence completion. Transcripts now store the Arabizi-transliterated text while keeping the original canonical Arabic text for reference.

## Details

The transliteration service purely romanizes Arabic text without translating it, allowing learners to see phonetic representations of the audio they hear. This complements the existing scaffolded text feature which provides translations with familiar words kept as Arabizi.