### PR TITLE
fix(config): copy Supabase env files during worktree creation

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -114,6 +114,9 @@ copy_env ".env"
 copy_env "web-api/.env"
 copy_env "web-app/.env"
 copy_env "admin-app/.env"
+copy_env "supabase/.env"
+copy_env "supabase/.env.keys"
+copy_env "supabase/.env.local"
 
 # ---------------------------------------------------------------------------
 # Patch .claude/launch.json with worktree-specific ports


### PR DESCRIPTION
## Summary
- Adds `supabase/.env`, `supabase/.env.keys`, and `supabase/.env.local` to the worktree creation hook so new worktrees have Supabase configuration for local development.

## Test plan
- [ ] Create a new worktree and verify the three Supabase env files are copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)