### PR TITLE
feat(web-app): show word meaning popover on hover for desktop

### DIFF
--- a/admin-app/package-lock.json
+++ b/admin-app/package-lock.json
@@ -3459,6 +3459,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5187,15 +5196,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -5020,6 +5020,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -9477,15 +9486,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "devOptional": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/web-app/src/components/Transcript/HighlightedText.tsx
+++ b/web-app/src/components/Transcript/HighlightedText.tsx
@@ -40,15 +40,41 @@ export function HighlightedText({ text, highlights }: HighlightedTextProps) {
     }
   }, [popover]);
 
-  const handleWordClick = useCallback(
-    (meaning: string, e: React.MouseEvent) => {
-      e.stopPropagation();
-      const rect = (e.target as HTMLElement).getBoundingClientRect();
+  const showPopover = useCallback(
+    (meaning: string, target: HTMLElement) => {
+      const rect = target.getBoundingClientRect();
       setPopover({
         meaning,
         top: rect.top - 4,
         left: rect.left + rect.width / 2,
       });
+    },
+    [],
+  );
+
+  const handleWordClick = useCallback(
+    (meaning: string, e: React.MouseEvent) => {
+      e.stopPropagation();
+      showPopover(meaning, e.currentTarget as HTMLElement);
+    },
+    [showPopover],
+  );
+
+  // Show on hover for mouse pointers only (not touch)
+  const handlePointerEnter = useCallback(
+    (meaning: string, e: React.PointerEvent) => {
+      if (e.pointerType === 'mouse') {
+        showPopover(meaning, e.currentTarget as HTMLElement);
+      }
+    },
+    [showPopover],
+  );
+
+  const handlePointerLeave = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.pointerType === 'mouse') {
+        setPopover(null);
+      }
     },
     [],
   );
@@ -81,6 +107,8 @@ export function HighlightedText({ text, highlights }: HighlightedTextProps) {
               fontWeight="medium"
               _hover={{ textDecoration: 'underline' }}
               onClick={(e) => handleWordClick(seg.highlight!.meaning, e)}
+              onPointerEnter={(e) => handlePointerEnter(seg.highlight!.meaning, e)}
+              onPointerLeave={handlePointerLeave}
             >
               {seg.text}
             </Text>


### PR DESCRIPTION
## Summary
- Highlighted Arabic words now show the meaning popover on mouse hover (desktop), in addition to click/tap
- Uses `onPointerEnter`/`onPointerLeave` with `pointerType === 'mouse'` check to distinguish mouse from touch — touch devices still require a tap
- Extracted shared `showPopover` helper; switched to `e.currentTarget` for reliable element targeting

## Test plan
- [ ] Desktop: hover over a highlighted word (e.g. "Marhaba") — popover should appear, then dismiss on mouse leave
- [ ] Desktop: click a highlighted word — popover should appear and stay until clicking elsewhere
- [ ] Mobile/touch: tap a highlighted word — popover should appear; hover should not trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)