### PR TITLE
feat: add Terraform modules and envs (dormant)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,11 @@ supabase/.env.keys
 
 # Task runner
 .task/
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+terraform.tfvars
+*.auto.tfvars

--- a/aws/README.md
+++ b/aws/README.md
@@ -1,0 +1,105 @@
+# Infra — Terraform
+
+AWS infrastructure for arabic-voice-agent, managed with Terraform.
+
+## Layout
+
+```
+aws/
+├── shared/          # env: VPC, ECR, IAM role, EC2 instance profile
+│   └── modules/     # reusable modules (called by prod + preview)
+├── prod/            # env: prod API EC2, static-sites S3 + CloudFront
+└── preview/         # env: shared preview EC2, preview static S3 + CloudFront
+```
+
+Each env has its own remote state in the `mishmish-tf-state` S3 bucket.
+
+## One-time state backend setup
+
+Before applying any env for the first time, create the state bucket. This is
+done once per AWS account with admin credentials.
+
+```bash
+aws s3api create-bucket --bucket mishmish-tf-state \
+  --region us-west-2 \
+  --create-bucket-configuration LocationConstraint=us-west-2
+
+aws s3api put-bucket-versioning --bucket mishmish-tf-state \
+  --versioning-configuration Status=Enabled
+
+aws s3api put-bucket-encryption --bucket mishmish-tf-state \
+  --server-side-encryption-configuration \
+  '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+
+aws s3api put-public-access-block --bucket mishmish-tf-state \
+  --public-access-block-configuration \
+  'BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true'
+
+aws s3api put-bucket-ownership-controls --bucket mishmish-tf-state \
+  --ownership-controls 'Rules=[{ObjectOwnership=BucketOwnerEnforced}]'
+
+aws s3api put-bucket-lifecycle-configuration --bucket mishmish-tf-state \
+  --lifecycle-configuration '{
+    "Rules": [
+      {
+        "ID": "expire-noncurrent-versions",
+        "Status": "Enabled",
+        "Filter": {},
+        "NoncurrentVersionExpiration": { "NoncurrentDays": 90 },
+        "AbortIncompleteMultipartUpload": { "DaysAfterInitiation": 7 }
+      }
+    ]
+  }'
+```
+
+State locking uses Terraform 1.10+ native S3 locking (`use_lockfile = true`).
+No DynamoDB table required.
+
+## Prerequisites
+
+- **Terraform ≥ 1.10.0** (for native S3 state locking).
+- **AWS CLI** with credentials that can assume the `github-actions-preview-deploy`
+  role, or admin credentials for the one-time `shared` apply.
+- **GitHub OIDC provider** must already exist in the AWS account at
+  `https://token.actions.githubusercontent.com`. Terraform reads it via a data
+  source — it is NOT created here.
+- **ACM certificate** covering `mishmish.ai` and `*.mishmish.ai` must exist in
+  `us-east-1` (CloudFront requirement). Terraform reads it via a data source.
+- **Secrets Manager** secrets `mishmish/prod/api` and `mishmish/preview/api`
+  must exist with the expected keys (see `prod/main.tf`).
+
+## Applying an env
+
+```bash
+cd aws/shared  # or aws/prod, aws/preview
+terraform init
+terraform plan
+terraform apply
+```
+
+Order for first-time setup:
+
+1. `shared/` — VPC, ECR, IAM roles, instance profile.
+2. `prod/` — depends on `shared/` outputs via `terraform_remote_state`.
+3. `preview/` — depends on `shared/` outputs via `terraform_remote_state`.
+
+## Outputs consumed by CI
+
+The `github-actions-preview-deploy` role (created in `shared/`) is what CI
+assumes. GitHub repo secrets `AWS_ROLE_ARN` and `AWS_ECR_REGISTRY` must match
+the outputs of the `shared` env:
+
+```bash
+terraform -chdir=shared output -raw github_actions_role_arn
+terraform -chdir=shared output -raw ecr_api_url
+```
+
+CI workflows that deploy the API container and static sites read stack outputs
+from the `prod`/`preview` envs via `terraform output`.
+
+## Migration from CloudFormation (one-time)
+
+See the migration plan — resources in `aws/bootstrap/`, `aws/prod/template.yaml`,
+`aws/preview/template.yaml`, and `aws/claude-agent/` are replaced by this
+Terraform layout. The `claude.mishmish.ai` / App Runner service is dropped
+entirely as part of the migration.

--- a/aws/preview/backend.tf
+++ b/aws/preview/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "mishmish-tf-state"
+    key          = "preview/terraform.tfstate"
+    region       = "us-west-2"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/aws/preview/files/preview-spa-routing.js
+++ b/aws/preview/files/preview-spa-routing.js
@@ -1,0 +1,15 @@
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+  // Static assets (have file extension) — serve as-is
+  if (uri.match(/\.[a-zA-Z0-9]+$/)) {
+    return request;
+  }
+  // SPA route — rewrite to the PR + app's index.html
+  // Path format: /pr-{N}/web-app/... or /pr-{N}/admin-app/...
+  var match = uri.match(/^\/pr-\d+\/[^\/]+/);
+  if (match) {
+    request.uri = match[0] + '/index.html';
+  }
+  return request;
+}

--- a/aws/preview/main.tf
+++ b/aws/preview/main.tf
@@ -1,0 +1,102 @@
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = var.tags
+  }
+}
+
+data "terraform_remote_state" "shared" {
+  backend = "s3"
+  config = {
+    bucket = var.state_bucket_name
+    key    = "shared/terraform.tfstate"
+    region = var.region
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Shared preview API host (EC2) — PR-specific containers added via SSM
+# ---------------------------------------------------------------------------
+
+module "api_host" {
+  source = "../shared/modules/ec2-docker-host"
+
+  name                  = "api-preview.mishmish.ai"
+  vpc_id                = data.terraform_remote_state.shared.outputs.vpc_id
+  subnet_id             = data.terraform_remote_state.shared.outputs.public_subnet_id
+  instance_profile_name = data.terraform_remote_state.shared.outputs.ec2_instance_profile
+  region                = var.region
+  caddy_config_mode     = "preview-empty"
+  domain_name           = var.preview_domain
+  tags                  = var.tags
+}
+
+# ---------------------------------------------------------------------------
+# Shared preview static-sites S3 bucket + CloudFront
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "static" {
+  bucket        = "mishmish-preview"
+  force_destroy = true
+  tags          = var.tags
+}
+
+resource "aws_s3_bucket_ownership_controls" "static" {
+  bucket = aws_s3_bucket.static.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "static" {
+  bucket                  = aws_s3_bucket.static.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "static" {
+  bucket = aws_s3_bucket.static.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+module "static_site" {
+  source = "../shared/modules/cloudfront-site"
+
+  name                        = "mishmish-preview"
+  comment                     = "Shared preview static sites (all PRs)"
+  bucket_regional_domain_name = aws_s3_bucket.static.bucket_regional_domain_name
+  aliases                     = []
+  acm_certificate_arn         = ""
+  spa_error_routing           = false
+  cloudfront_function_code    = file("${path.module}/files/preview-spa-routing.js")
+  cloudfront_function_runtime = "cloudfront-js-2.0"
+  tags                        = var.tags
+}
+
+resource "aws_s3_bucket_policy" "static" {
+  bucket = aws_s3_bucket.static.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontOAC"
+        Effect    = "Allow"
+        Principal = { Service = "cloudfront.amazonaws.com" }
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.static.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = module.static_site.distribution_arn
+          }
+        }
+      },
+    ]
+  })
+}

--- a/aws/preview/outputs.tf
+++ b/aws/preview/outputs.tf
@@ -1,0 +1,20 @@
+output "preview_instance_id" {
+  value = module.api_host.instance_id
+}
+
+output "preview_elastic_ip" {
+  value       = module.api_host.public_ip
+  description = "Elastic IP — point *.preview.mishmish.ai A records here."
+}
+
+output "preview_static_bucket_name" {
+  value = aws_s3_bucket.static.bucket
+}
+
+output "preview_static_distribution_id" {
+  value = module.static_site.distribution_id
+}
+
+output "preview_static_distribution_domain" {
+  value = module.static_site.distribution_domain_name
+}

--- a/aws/preview/variables.tf
+++ b/aws/preview/variables.tf
@@ -1,0 +1,22 @@
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "state_bucket_name" {
+  type    = string
+  default = "mishmish-tf-state"
+}
+
+variable "preview_domain" {
+  type    = string
+  default = "api-preview.mishmish.ai"
+}
+
+variable "tags" {
+  type = map(string)
+  default = {
+    Project     = "arabic-voice-agent"
+    Environment = "preview"
+  }
+}

--- a/aws/preview/versions.tf
+++ b/aws/preview/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.70"
+    }
+  }
+}

--- a/aws/prod/backend.tf
+++ b/aws/prod/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "mishmish-tf-state"
+    key          = "prod/terraform.tfstate"
+    region       = "us-west-2"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/aws/prod/main.tf
+++ b/aws/prod/main.tf
@@ -1,0 +1,148 @@
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = var.tags
+  }
+}
+
+# CloudFront/ACM certs must live in us-east-1.
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+  default_tags {
+    tags = var.tags
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+data "terraform_remote_state" "shared" {
+  backend = "s3"
+  config = {
+    bucket = var.state_bucket_name
+    key    = "shared/terraform.tfstate"
+    region = var.region
+  }
+}
+
+data "aws_acm_certificate" "wildcard" {
+  provider    = aws.us_east_1
+  domain      = var.acm_certificate_domain
+  statuses    = ["ISSUED"]
+  most_recent = true
+}
+
+data "aws_secretsmanager_secret" "api" {
+  arn = var.api_secret_arn
+}
+
+# ---------------------------------------------------------------------------
+# API host — EC2 + Caddy + Docker
+# ---------------------------------------------------------------------------
+
+module "api_host" {
+  source = "../shared/modules/ec2-docker-host"
+
+  name                  = "api.mishmish.ai"
+  vpc_id                = data.terraform_remote_state.shared.outputs.vpc_id
+  subnet_id             = data.terraform_remote_state.shared.outputs.public_subnet_id
+  instance_profile_name = data.terraform_remote_state.shared.outputs.ec2_instance_profile
+  region                = var.region
+  caddy_config_mode     = "prod"
+  domain_name           = var.api_domain
+  container_image_uri   = var.api_image_uri
+  secret_arn            = data.aws_secretsmanager_secret.api.arn
+  tags                  = var.tags
+}
+
+# ---------------------------------------------------------------------------
+# Shared S3 bucket for web-app and admin-app (under /web-app and /admin-app)
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "static" {
+  bucket = "mishmish-prod"
+  tags   = var.tags
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "static" {
+  bucket = aws_s3_bucket.static.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "static" {
+  bucket                  = aws_s3_bucket.static.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "static" {
+  bucket = aws_s3_bucket.static.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# CloudFront distributions (web-app, admin-app)
+# ---------------------------------------------------------------------------
+
+module "web_app" {
+  source = "../shared/modules/cloudfront-site"
+
+  name                        = "mishmish-web-app"
+  comment                     = "Production - web-app"
+  bucket_regional_domain_name = aws_s3_bucket.static.bucket_regional_domain_name
+  origin_path                 = "/web-app"
+  aliases                     = var.web_app_aliases
+  acm_certificate_arn         = data.aws_acm_certificate.wildcard.arn
+  spa_error_routing           = true
+  tags                        = var.tags
+}
+
+module "admin_app" {
+  source = "../shared/modules/cloudfront-site"
+
+  name                        = "mishmish-admin-app"
+  comment                     = "Production - admin"
+  bucket_regional_domain_name = aws_s3_bucket.static.bucket_regional_domain_name
+  origin_path                 = "/admin-app"
+  aliases                     = var.admin_aliases
+  acm_certificate_arn         = data.aws_acm_certificate.wildcard.arn
+  spa_error_routing           = true
+  tags                        = var.tags
+}
+
+resource "aws_s3_bucket_policy" "static" {
+  bucket = aws_s3_bucket.static.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontOAC"
+        Effect    = "Allow"
+        Principal = { Service = "cloudfront.amazonaws.com" }
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.static.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = [
+              module.web_app.distribution_arn,
+              module.admin_app.distribution_arn,
+            ]
+          }
+        }
+      },
+    ]
+  })
+}

--- a/aws/prod/outputs.tf
+++ b/aws/prod/outputs.tf
@@ -1,0 +1,35 @@
+output "api_instance_id" {
+  value       = module.api_host.instance_id
+  description = "EC2 instance ID for the prod API (used by SSM deploy)."
+}
+
+output "api_elastic_ip" {
+  value       = module.api_host.public_ip
+  description = "Elastic IP — point api.mishmish.ai A record here."
+}
+
+output "api_url" {
+  value = "https://${var.api_domain}"
+}
+
+output "static_bucket_name" {
+  value = aws_s3_bucket.static.bucket
+}
+
+output "web_app_distribution_id" {
+  value = module.web_app.distribution_id
+}
+
+output "web_app_cloudfront_domain" {
+  value       = module.web_app.distribution_domain_name
+  description = "Point mishmish.ai and www.mishmish.ai to this domain."
+}
+
+output "admin_distribution_id" {
+  value = module.admin_app.distribution_id
+}
+
+output "admin_cloudfront_domain" {
+  value       = module.admin_app.distribution_domain_name
+  description = "Point admin.mishmish.ai to this domain."
+}

--- a/aws/prod/variables.tf
+++ b/aws/prod/variables.tf
@@ -1,0 +1,49 @@
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "state_bucket_name" {
+  type        = string
+  default     = "mishmish-tf-state"
+  description = "Terraform state bucket (used to read shared env outputs)."
+}
+
+variable "api_image_uri" {
+  type        = string
+  description = "Full ECR image URI for the API container (e.g. 123.dkr.ecr.us-west-2.amazonaws.com/arabic-voice-agent-api:v1.2.3)."
+}
+
+variable "api_secret_arn" {
+  type        = string
+  description = "ARN of the Secrets Manager secret mishmish/prod/api."
+}
+
+variable "api_domain" {
+  type    = string
+  default = "api.mishmish.ai"
+}
+
+variable "acm_certificate_domain" {
+  type        = string
+  default     = "*.mishmish.ai"
+  description = "ACM certificate domain (looked up in us-east-1)."
+}
+
+variable "web_app_aliases" {
+  type    = list(string)
+  default = ["mishmish.ai", "www.mishmish.ai"]
+}
+
+variable "admin_aliases" {
+  type    = list(string)
+  default = ["admin.mishmish.ai"]
+}
+
+variable "tags" {
+  type = map(string)
+  default = {
+    Project     = "arabic-voice-agent"
+    Environment = "production"
+  }
+}

--- a/aws/prod/versions.tf
+++ b/aws/prod/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.70"
+    }
+  }
+}

--- a/aws/shared/backend.tf
+++ b/aws/shared/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "mishmish-tf-state"
+    key          = "shared/terraform.tfstate"
+    region       = "us-west-2"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/aws/shared/main.tf
+++ b/aws/shared/main.tf
@@ -1,0 +1,146 @@
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = var.tags
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+# ---------------------------------------------------------------------------
+# VPC + ECR
+# ---------------------------------------------------------------------------
+
+module "vpc" {
+  source = "./modules/vpc"
+  name   = "arabic-voice-agent"
+  tags   = var.tags
+}
+
+module "ecr_api" {
+  source = "./modules/ecr-repo"
+  name   = "arabic-voice-agent-api"
+  tags   = var.tags
+}
+
+# ---------------------------------------------------------------------------
+# EC2 instance role (shared by prod + preview API hosts)
+# ---------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "ec2_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ec2_instance" {
+  name               = "mishmish-ec2-instance"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_ssm" {
+  role       = aws_iam_role.ec2_instance.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy" "ec2_secrets_read" {
+  name = "SecretsManagerRead"
+  role = aws_iam_role.ec2_instance.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "ec2_ecr_pull" {
+  name = "EcrPull"
+  role = aws_iam_role.ec2_instance.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+        ]
+        Resource = [module.ecr_api.repository_arn]
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "ec2_cloudwatch_logs" {
+  name = "CloudWatchLogs"
+  role = aws_iam_role.ec2_instance.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_instance_profile" "ec2_instance" {
+  name = "mishmish-ec2-instance"
+  role = aws_iam_role.ec2_instance.name
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------------------
+# GitHub Actions OIDC role
+# ---------------------------------------------------------------------------
+
+locals {
+  deploy_policy_json = templatefile("${path.module}/policies/github-actions-deploy.json.tftpl", {
+    account_id        = data.aws_caller_identity.current.account_id
+    region            = var.region
+    state_bucket_name = var.state_bucket_name
+    ec2_role_arn      = aws_iam_role.ec2_instance.arn
+  })
+}
+
+module "github_actions_role" {
+  source             = "./modules/github-actions-oidc-role"
+  role_name          = "github-actions-preview-deploy"
+  oidc_provider_arn  = data.aws_iam_openid_connect_provider.github.arn
+  github_org         = var.github_org
+  github_repo        = var.github_repo
+  allowed_refs       = ["repo:${var.github_org}/${var.github_repo}:*"]
+  inline_policy_json = local.deploy_policy_json
+  tags               = var.tags
+}

--- a/aws/shared/modules/cloudfront-site/main.tf
+++ b/aws/shared/modules/cloudfront-site/main.tf
@@ -1,0 +1,82 @@
+locals {
+  use_custom_domain = var.acm_certificate_arn != ""
+  use_function      = var.cloudfront_function_code != ""
+  # CloudFront managed cache policy: CachingOptimized
+  caching_optimized_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+}
+
+resource "aws_cloudfront_origin_access_control" "this" {
+  name                              = var.name
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_function" "this" {
+  count   = local.use_function ? 1 : 0
+  name    = "${var.name}-viewer-request"
+  runtime = var.cloudfront_function_runtime
+  publish = true
+  code    = var.cloudfront_function_code
+}
+
+resource "aws_cloudfront_distribution" "this" {
+  enabled             = true
+  comment             = var.comment
+  default_root_object = var.default_root_object
+  price_class         = "PriceClass_100"
+  aliases             = var.aliases
+
+  origin {
+    origin_id                = "S3Origin"
+    domain_name              = var.bucket_regional_domain_name
+    origin_path              = var.origin_path
+    origin_access_control_id = aws_cloudfront_origin_access_control.this.id
+
+    s3_origin_config {
+      origin_access_identity = ""
+    }
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "S3Origin"
+    viewer_protocol_policy = "redirect-to-https"
+    cache_policy_id        = local.caching_optimized_policy_id
+    compress               = true
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+
+    dynamic "function_association" {
+      for_each = local.use_function ? [1] : []
+      content {
+        event_type   = "viewer-request"
+        function_arn = aws_cloudfront_function.this[0].arn
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = local.use_custom_domain ? false : true
+    acm_certificate_arn            = local.use_custom_domain ? var.acm_certificate_arn : null
+    ssl_support_method             = local.use_custom_domain ? "sni-only" : null
+    minimum_protocol_version       = local.use_custom_domain ? "TLSv1.2_2021" : null
+  }
+
+  dynamic "custom_error_response" {
+    for_each = var.spa_error_routing ? [403, 404] : []
+    content {
+      error_code            = custom_error_response.value
+      response_code         = 200
+      response_page_path    = "/index.html"
+      error_caching_min_ttl = 0
+    }
+  }
+
+  tags = var.tags
+}

--- a/aws/shared/modules/cloudfront-site/outputs.tf
+++ b/aws/shared/modules/cloudfront-site/outputs.tf
@@ -1,0 +1,15 @@
+output "distribution_id" {
+  value = aws_cloudfront_distribution.this.id
+}
+
+output "distribution_arn" {
+  value = aws_cloudfront_distribution.this.arn
+}
+
+output "distribution_domain_name" {
+  value = aws_cloudfront_distribution.this.domain_name
+}
+
+output "oac_id" {
+  value = aws_cloudfront_origin_access_control.this.id
+}

--- a/aws/shared/modules/cloudfront-site/variables.tf
+++ b/aws/shared/modules/cloudfront-site/variables.tf
@@ -1,0 +1,63 @@
+variable "name" {
+  type        = string
+  description = "Name used for OAC and as Name tag. Must be unique per distribution in the account."
+}
+
+variable "comment" {
+  type        = string
+  default     = ""
+  description = "Distribution comment."
+}
+
+variable "bucket_regional_domain_name" {
+  type        = string
+  description = "Regional domain name of the S3 origin bucket (e.g. mishmish-prod.s3.us-west-2.amazonaws.com)."
+}
+
+variable "origin_path" {
+  type        = string
+  default     = ""
+  description = "Optional origin path prefix (e.g. /web-app). Leading slash, no trailing slash."
+}
+
+variable "aliases" {
+  type        = list(string)
+  default     = []
+  description = "Custom domain aliases for the distribution."
+}
+
+variable "acm_certificate_arn" {
+  type        = string
+  default     = ""
+  description = "ACM certificate ARN (us-east-1). Empty string means use the default CloudFront certificate."
+}
+
+variable "default_root_object" {
+  type        = string
+  default     = "index.html"
+  description = "Default root object for the distribution."
+}
+
+variable "spa_error_routing" {
+  type        = bool
+  default     = true
+  description = "Map 403/404 errors to /index.html (SPA routing)."
+}
+
+variable "cloudfront_function_code" {
+  type        = string
+  default     = ""
+  description = "JavaScript source for an attached CloudFront Function (viewer-request). Empty disables."
+}
+
+variable "cloudfront_function_runtime" {
+  type        = string
+  default     = "cloudfront-js-2.0"
+  description = "Runtime for the CloudFront Function."
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags applied to the distribution and OAC."
+}

--- a/aws/shared/modules/cloudfront-site/versions.tf
+++ b/aws/shared/modules/cloudfront-site/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.70"
+    }
+  }
+}

--- a/aws/shared/modules/ec2-docker-host/main.tf
+++ b/aws/shared/modules/ec2-docker-host/main.tf
@@ -1,0 +1,69 @@
+data "aws_ssm_parameter" "al2023_ami" {
+  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+}
+
+locals {
+  user_data = templatefile("${path.module}/templates/userdata.sh.tftpl", {
+    caddy_mode  = var.caddy_config_mode
+    domain_name = var.domain_name
+    image_uri   = var.container_image_uri
+    secret_arn  = var.secret_arn
+    region      = var.region
+  })
+}
+
+resource "aws_security_group" "this" {
+  name        = var.name
+  description = "Allow HTTP/HTTPS inbound to ${var.name}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, { Name = var.name })
+}
+
+resource "aws_eip" "this" {
+  domain = "vpc"
+  tags   = merge(var.tags, { Name = var.name })
+}
+
+resource "aws_instance" "this" {
+  ami                         = data.aws_ssm_parameter.al2023_ami.value
+  instance_type               = var.instance_type
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = [aws_security_group.this.id]
+  iam_instance_profile        = var.instance_profile_name
+  user_data                   = local.user_data
+  user_data_replace_on_change = false
+
+  root_block_device {
+    volume_size = var.volume_size_gb
+    volume_type = "gp3"
+  }
+
+  tags = merge(var.tags, { Name = var.name })
+}
+
+resource "aws_eip_association" "this" {
+  allocation_id = aws_eip.this.allocation_id
+  instance_id   = aws_instance.this.id
+}

--- a/aws/shared/modules/ec2-docker-host/outputs.tf
+++ b/aws/shared/modules/ec2-docker-host/outputs.tf
@@ -1,0 +1,15 @@
+output "instance_id" {
+  value = aws_instance.this.id
+}
+
+output "public_ip" {
+  value = aws_eip.this.public_ip
+}
+
+output "eip_allocation_id" {
+  value = aws_eip.this.allocation_id
+}
+
+output "security_group_id" {
+  value = aws_security_group.this.id
+}

--- a/aws/shared/modules/ec2-docker-host/templates/userdata.sh.tftpl
+++ b/aws/shared/modules/ec2-docker-host/templates/userdata.sh.tftpl
@@ -1,0 +1,113 @@
+#!/bin/bash
+set -euo pipefail
+
+# Log all output
+exec > >(tee /var/log/user-data.log) 2>&1
+echo "=== Starting cloud-init at $(date) ==="
+
+# Install Docker
+dnf install -y docker
+systemctl enable docker
+systemctl start docker
+
+# Install Caddy (direct binary — AL2023 has no RPM package)
+curl -sL "https://github.com/caddyserver/caddy/releases/download/v2.9.1/caddy_2.9.1_linux_amd64.tar.gz" -o /tmp/caddy.tar.gz
+tar xzf /tmp/caddy.tar.gz -C /usr/bin caddy
+chmod +x /usr/bin/caddy
+rm /tmp/caddy.tar.gz
+
+# Create caddy user/group and systemd service
+groupadd -r caddy 2>/dev/null || true
+useradd -r -g caddy -d /var/lib/caddy -s /sbin/nologin caddy 2>/dev/null || true
+mkdir -p /var/lib/caddy /etc/caddy /var/log/caddy
+chown caddy:caddy /var/lib/caddy /var/log/caddy
+
+cat > /etc/systemd/system/caddy.service <<'SVCEOF'
+[Unit]
+Description=Caddy
+After=network.target
+[Service]
+User=caddy
+Group=caddy
+ExecStart=/usr/bin/caddy run --environ --config /etc/caddy/Caddyfile
+ExecReload=/usr/bin/caddy reload --config /etc/caddy/Caddyfile
+TimeoutStopSec=5s
+LimitNOFILE=1048576
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+Restart=on-failure
+[Install]
+WantedBy=multi-user.target
+SVCEOF
+systemctl daemon-reload
+systemctl enable caddy
+
+# Install jq for JSON parsing
+dnf install -y jq
+
+# Create config directory
+mkdir -p /etc/mishmish
+
+%{ if caddy_mode == "prod" ~}
+# ---- prod mode: fetch secrets, pull image, run container ----
+
+SECRET_JSON=$(aws secretsmanager get-secret-value \
+  --secret-id "${secret_arn}" \
+  --region "${region}" \
+  --query SecretString --output text)
+
+echo "SUPABASE_URL=$(echo "$SECRET_JSON" | jq -r '.SUPABASE_URL')" > /etc/mishmish/api.env
+echo "SUPABASE_PUBLISHABLE_KEY=$(echo "$SECRET_JSON" | jq -r '.SUPABASE_PUBLISHABLE_KEY')" >> /etc/mishmish/api.env
+echo "SUPABASE_SECRET_KEY=$(echo "$SECRET_JSON" | jq -r '.SUPABASE_SECRET_KEY')" >> /etc/mishmish/api.env
+echo "OPENAI_API_KEY=$(echo "$SECRET_JSON" | jq -r '.OPENAI_API_KEY')" >> /etc/mishmish/api.env
+echo "SONIOX_API_KEY=$(echo "$SECRET_JSON" | jq -r '.SONIOX_API_KEY')" >> /etc/mishmish/api.env
+echo "ELEVEN_API_KEY=$(echo "$SECRET_JSON" | jq -r '.ELEVEN_API_KEY')" >> /etc/mishmish/api.env
+echo "PORT=8000" >> /etc/mishmish/api.env
+chmod 600 /etc/mishmish/api.env
+
+# ECR login and pull initial image
+ECR_REGISTRY=$(echo "${image_uri}" | cut -d'/' -f1)
+aws ecr get-login-password --region "${region}" | \
+  docker login --username AWS --password-stdin "$ECR_REGISTRY"
+docker pull "${image_uri}"
+
+# Run the API container
+docker run -d \
+  --name api \
+  --restart unless-stopped \
+  -p 8000:8000 \
+  --env-file /etc/mishmish/api.env \
+  "${image_uri}"
+
+# Write Caddyfile
+cat > /etc/caddy/Caddyfile <<'CADDYEOF'
+${domain_name} {
+  # CORS headers — belt-and-suspenders with FastAPI CORSMiddleware
+  # so that even 5xx errors from the app always include CORS headers.
+  @cors_preflight method OPTIONS
+  handle @cors_preflight {
+    header Access-Control-Allow-Origin "*"
+    header Access-Control-Allow-Methods "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+    header Access-Control-Allow-Headers "*"
+    header Access-Control-Max-Age "86400"
+    respond "" 204
+  }
+  # ? prefix = set only if not already present (avoids duplicate with FastAPI)
+  header ?Access-Control-Allow-Origin "*"
+  header ?Access-Control-Allow-Methods "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+  header ?Access-Control-Allow-Headers "*"
+
+  reverse_proxy localhost:8000
+}
+CADDYEOF
+%{ else ~}
+# ---- preview-empty mode: empty Caddyfile; PR blocks added via SSM ----
+cat > /etc/caddy/Caddyfile <<'CADDYEOF'
+# Preview — PR-specific blocks are appended below by GitHub Actions.
+# Each block routes api-pr-X, pr-X, and admin-pr-X subdomains.
+CADDYEOF
+%{ endif ~}
+
+# Start Caddy
+systemctl start caddy
+
+echo "=== Cloud-init complete at $(date) ==="

--- a/aws/shared/modules/ec2-docker-host/variables.tf
+++ b/aws/shared/modules/ec2-docker-host/variables.tf
@@ -1,0 +1,69 @@
+variable "name" {
+  type        = string
+  description = "Name tag for instance, security group, and EIP."
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID for the security group."
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "Subnet ID for the instance."
+}
+
+variable "instance_profile_name" {
+  type        = string
+  description = "EC2 instance profile name (from shared env)."
+}
+
+variable "instance_type" {
+  type        = string
+  default     = "t3.micro"
+  description = "EC2 instance type."
+}
+
+variable "volume_size_gb" {
+  type        = number
+  default     = 20
+  description = "Root EBS volume size in GiB."
+}
+
+variable "caddy_config_mode" {
+  type        = string
+  description = "Either 'prod' (Caddy reverse-proxies to local container) or 'preview-empty' (empty Caddyfile; per-PR blocks appended via SSM)."
+  validation {
+    condition     = contains(["prod", "preview-empty"], var.caddy_config_mode)
+    error_message = "caddy_config_mode must be 'prod' or 'preview-empty'."
+  }
+}
+
+variable "domain_name" {
+  type        = string
+  default     = ""
+  description = "Domain Caddy should serve (prod mode). Unused in preview-empty mode."
+}
+
+variable "container_image_uri" {
+  type        = string
+  default     = ""
+  description = "Full ECR image URI to pull and run on first boot (prod mode only)."
+}
+
+variable "secret_arn" {
+  type        = string
+  default     = ""
+  description = "Secrets Manager secret ARN containing API env vars (prod mode only)."
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region (used inside UserData for CLI calls)."
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags applied to instance, SG, and EIP."
+}

--- a/aws/shared/modules/ec2-docker-host/versions.tf
+++ b/aws/shared/modules/ec2-docker-host/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.70"
+    }
+  }
+}

--- a/aws/shared/modules/ecr-repo/main.tf
+++ b/aws/shared/modules/ecr-repo/main.tf
@@ -1,0 +1,32 @@
+resource "aws_ecr_repository" "this" {
+  name                 = var.name
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  repository = aws_ecr_repository.this.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Delete untagged images older than ${var.untagged_retention_days} days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = var.untagged_retention_days
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/aws/shared/modules/ecr-repo/outputs.tf
+++ b/aws/shared/modules/ecr-repo/outputs.tf
@@ -1,0 +1,11 @@
+output "repository_url" {
+  value = aws_ecr_repository.this.repository_url
+}
+
+output "repository_arn" {
+  value = aws_ecr_repository.this.arn
+}
+
+output "name" {
+  value = aws_ecr_repository.this.name
+}

--- a/aws/shared/modules/ecr-repo/variables.tf
+++ b/aws/shared/modules/ecr-repo/variables.tf
@@ -1,0 +1,16 @@
+variable "name" {
+  type        = string
+  description = "Repository name."
+}
+
+variable "untagged_retention_days" {
+  type        = number
+  default     = 7
+  description = "Expire untagged images after this many days."
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags applied to the repository."
+}

--- a/aws/shared/modules/ecr-repo/versions.tf
+++ b/aws/shared/modules/ecr-repo/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.70"
+    }
+  }
+}

--- a/aws/shared/modules/github-actions-oidc-role/main.tf
+++ b/aws/shared/modules/github-actions-oidc-role/main.tf
@@ -1,0 +1,35 @@
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = var.allowed_refs
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name               = var.role_name
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy" "inline" {
+  name   = "DeployPolicy"
+  role   = aws_iam_role.this.id
+  policy = var.inline_policy_json
+}

--- a/aws/shared/modules/github-actions-oidc-role/outputs.tf
+++ b/aws/shared/modules/github-actions-oidc-role/outputs.tf
@@ -1,0 +1,7 @@
+output "role_arn" {
+  value = aws_iam_role.this.arn
+}
+
+output "role_name" {
+  value = aws_iam_role.this.name
+}

--- a/aws/shared/modules/github-actions-oidc-role/variables.tf
+++ b/aws/shared/modules/github-actions-oidc-role/variables.tf
@@ -1,0 +1,35 @@
+variable "role_name" {
+  type        = string
+  description = "Name of the IAM role."
+}
+
+variable "oidc_provider_arn" {
+  type        = string
+  description = "ARN of the existing GitHub OIDC provider in this account."
+}
+
+variable "github_org" {
+  type        = string
+  description = "GitHub organization or user owning the repo."
+}
+
+variable "github_repo" {
+  type        = string
+  description = "GitHub repository name."
+}
+
+variable "allowed_refs" {
+  type        = list(string)
+  description = "List of sub-claim patterns (repo:ORG/REPO:*) allowed to assume the role."
+}
+
+variable "inline_policy_json" {
+  type        = string
+  description = "Inline policy JSON to attach to the role."
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags applied to the role."
+}

--- a/aws/shared/modules/github-actions-oidc-role/versions.tf
+++ b/aws/shared/modules/github-actions-oidc-role/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.70"
+    }
+  }
+}

--- a/aws/shared/modules/vpc/main.tf
+++ b/aws/shared/modules/vpc/main.tf
@@ -1,0 +1,43 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  az = coalesce(var.availability_zone, data.aws_availability_zones.available.names[0])
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags                 = merge(var.tags, { Name = var.name })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+  tags   = var.tags
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidr
+  availability_zone       = local.az
+  map_public_ip_on_launch = true
+  tags                    = merge(var.tags, { Name = "${var.name}-public-a" })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+  tags   = var.tags
+}
+
+resource "aws_route" "public_internet" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}

--- a/aws/shared/modules/vpc/outputs.tf
+++ b/aws/shared/modules/vpc/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.this.id
+}
+
+output "public_subnet_id" {
+  value = aws_subnet.public.id
+}
+
+output "internet_gateway_id" {
+  value = aws_internet_gateway.this.id
+}

--- a/aws/shared/modules/vpc/variables.tf
+++ b/aws/shared/modules/vpc/variables.tf
@@ -1,0 +1,28 @@
+variable "name" {
+  type        = string
+  description = "Name tag prefix for all VPC resources."
+}
+
+variable "cidr_block" {
+  type        = string
+  default     = "10.0.0.0/16"
+  description = "CIDR block for the VPC."
+}
+
+variable "public_subnet_cidr" {
+  type        = string
+  default     = "10.0.1.0/24"
+  description = "CIDR block for the single public subnet."
+}
+
+variable "availability_zone" {
+  type        = string
+  default     = null
+  description = "AZ for the public subnet. Defaults to the first AZ in the region."
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags applied to all resources."
+}

--- a/aws/shared/modules/vpc/versions.tf
+++ b/aws/shared/modules/vpc/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.70"
+    }
+  }
+}

--- a/aws/shared/outputs.tf
+++ b/aws/shared/outputs.tf
@@ -1,0 +1,29 @@
+output "github_actions_role_arn" {
+  value       = module.github_actions_role.role_arn
+  description = "IAM role ARN for GitHub Actions (set as GitHub secret AWS_ROLE_ARN)."
+}
+
+output "ecr_api_url" {
+  value       = module.ecr_api.repository_url
+  description = "ECR repository URI for the web-api (set as GitHub secret AWS_ECR_REGISTRY)."
+}
+
+output "ecr_api_arn" {
+  value = module.ecr_api.repository_arn
+}
+
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "public_subnet_id" {
+  value = module.vpc.public_subnet_id
+}
+
+output "ec2_instance_profile" {
+  value = aws_iam_instance_profile.ec2_instance.name
+}
+
+output "ec2_instance_role_arn" {
+  value = aws_iam_role.ec2_instance.arn
+}

--- a/aws/shared/policies/github-actions-deploy.json.tftpl
+++ b/aws/shared/policies/github-actions-deploy.json.tftpl
@@ -1,0 +1,268 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "TerraformStateBackend",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket",
+        "s3:GetBucketVersioning"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${state_bucket_name}",
+        "arn:aws:s3:::${state_bucket_name}/*"
+      ]
+    },
+    {
+      "Sid": "EcrAuth",
+      "Effect": "Allow",
+      "Action": ["ecr:GetAuthorizationToken"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "EcrReadWrite",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:BatchDeleteImage",
+        "ecr:DescribeRepositories",
+        "ecr:DescribeImages",
+        "ecr:ListImages",
+        "ecr:GetRepositoryPolicy",
+        "ecr:GetLifecyclePolicy"
+      ],
+      "Resource": [
+        "arn:aws:ecr:${region}:${account_id}:repository/arabic-voice-agent-api"
+      ]
+    },
+    {
+      "Sid": "S3AppBuckets",
+      "Effect": "Allow",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:DeleteBucket",
+        "s3:PutBucketPolicy",
+        "s3:GetBucketPolicy",
+        "s3:DeleteBucketPolicy",
+        "s3:PutBucketWebsite",
+        "s3:GetBucketWebsite",
+        "s3:DeleteBucketWebsite",
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:GetBucketVersioning",
+        "s3:PutBucketVersioning",
+        "s3:PutBucketPublicAccessBlock",
+        "s3:GetBucketPublicAccessBlock",
+        "s3:PutBucketOwnershipControls",
+        "s3:GetBucketOwnershipControls",
+        "s3:PutBucketEncryption",
+        "s3:GetEncryptionConfiguration",
+        "s3:TagResource",
+        "s3:PutBucketTagging",
+        "s3:GetBucketTagging"
+      ],
+      "Resource": [
+        "arn:aws:s3:::mishmish-preview",
+        "arn:aws:s3:::mishmish-preview/*",
+        "arn:aws:s3:::mishmish-prod",
+        "arn:aws:s3:::mishmish-prod/*"
+      ]
+    },
+    {
+      "Sid": "CloudFront",
+      "Effect": "Allow",
+      "Action": [
+        "cloudfront:CreateDistribution",
+        "cloudfront:UpdateDistribution",
+        "cloudfront:DeleteDistribution",
+        "cloudfront:GetDistribution",
+        "cloudfront:GetDistributionConfig",
+        "cloudfront:ListDistributions",
+        "cloudfront:CreateInvalidation",
+        "cloudfront:GetInvalidation",
+        "cloudfront:ListInvalidations",
+        "cloudfront:CreateOriginAccessControl",
+        "cloudfront:DeleteOriginAccessControl",
+        "cloudfront:GetOriginAccessControl",
+        "cloudfront:GetOriginAccessControlConfig",
+        "cloudfront:UpdateOriginAccessControl",
+        "cloudfront:ListOriginAccessControls",
+        "cloudfront:CreateFunction",
+        "cloudfront:UpdateFunction",
+        "cloudfront:DeleteFunction",
+        "cloudfront:DescribeFunction",
+        "cloudfront:GetFunction",
+        "cloudfront:ListFunctions",
+        "cloudfront:PublishFunction",
+        "cloudfront:TestFunction",
+        "cloudfront:TagResource",
+        "cloudfront:UntagResource",
+        "cloudfront:ListTagsForResource"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "Ec2",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:TerminateInstances",
+        "ec2:StartInstances",
+        "ec2:StopInstances",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInstanceAttribute",
+        "ec2:CreateSecurityGroup",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DescribeSecurityGroups",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:AuthorizeSecurityGroupEgress",
+        "ec2:RevokeSecurityGroupEgress",
+        "ec2:AllocateAddress",
+        "ec2:ReleaseAddress",
+        "ec2:AssociateAddress",
+        "ec2:DisassociateAddress",
+        "ec2:DescribeAddresses",
+        "ec2:DescribeAddressesAttribute",
+        "ec2:CreateVpc",
+        "ec2:DeleteVpc",
+        "ec2:ModifyVpcAttribute",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeVpcAttribute",
+        "ec2:CreateSubnet",
+        "ec2:DeleteSubnet",
+        "ec2:ModifySubnetAttribute",
+        "ec2:DescribeSubnets",
+        "ec2:CreateInternetGateway",
+        "ec2:DeleteInternetGateway",
+        "ec2:AttachInternetGateway",
+        "ec2:DetachInternetGateway",
+        "ec2:DescribeInternetGateways",
+        "ec2:CreateRouteTable",
+        "ec2:DeleteRouteTable",
+        "ec2:CreateRoute",
+        "ec2:DeleteRoute",
+        "ec2:DescribeRouteTables",
+        "ec2:AssociateRouteTable",
+        "ec2:DisassociateRouteTable",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeImages",
+        "ec2:DescribeKeyPairs",
+        "ec2:CreateTags",
+        "ec2:DeleteTags",
+        "ec2:DescribeTags",
+        "ec2:CreateLaunchTemplate",
+        "ec2:DeleteLaunchTemplate",
+        "ec2:DescribeLaunchTemplates",
+        "ec2:DescribeLaunchTemplateVersions",
+        "ec2:CreateLaunchTemplateVersion",
+        "ec2:DescribeSpotPriceHistory",
+        "ec2:DescribeVolumes"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "Ssm",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand",
+        "ssm:GetCommandInvocation",
+        "ssm:DescribeInstanceInformation",
+        "ssm:GetParameters",
+        "ssm:GetParameter"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "IamRoles",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:GetRole",
+        "iam:UpdateAssumeRolePolicy",
+        "iam:PutRolePolicy",
+        "iam:DeleteRolePolicy",
+        "iam:GetRolePolicy",
+        "iam:AttachRolePolicy",
+        "iam:DetachRolePolicy",
+        "iam:ListAttachedRolePolicies",
+        "iam:ListRolePolicies",
+        "iam:TagRole",
+        "iam:UntagRole",
+        "iam:ListRoleTags",
+        "iam:CreateInstanceProfile",
+        "iam:DeleteInstanceProfile",
+        "iam:GetInstanceProfile",
+        "iam:AddRoleToInstanceProfile",
+        "iam:RemoveRoleFromInstanceProfile"
+      ],
+      "Resource": [
+        "arn:aws:iam::${account_id}:role/prod-*",
+        "arn:aws:iam::${account_id}:role/preview-*",
+        "arn:aws:iam::${account_id}:role/mishmish-*",
+        "arn:aws:iam::${account_id}:instance-profile/mishmish-*"
+      ]
+    },
+    {
+      "Sid": "IamListOidc",
+      "Effect": "Allow",
+      "Action": ["iam:ListOpenIDConnectProviders", "iam:GetOpenIDConnectProvider"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PassRole",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": [
+        "${ec2_role_arn}",
+        "arn:aws:iam::${account_id}:role/prod-*",
+        "arn:aws:iam::${account_id}:role/preview-*",
+        "arn:aws:iam::${account_id}:role/mishmish-*"
+      ]
+    },
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:DeleteLogGroup",
+        "logs:DescribeLogGroups",
+        "logs:PutRetentionPolicy"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "AcmRead",
+      "Effect": "Allow",
+      "Action": [
+        "acm:DescribeCertificate",
+        "acm:ListCertificates"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SecretsRead",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:ListSecrets"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/aws/shared/variables.tf
+++ b/aws/shared/variables.tf
@@ -1,0 +1,31 @@
+variable "region" {
+  type        = string
+  default     = "us-west-2"
+  description = "AWS region."
+}
+
+variable "github_org" {
+  type        = string
+  default     = "tanyagray"
+  description = "GitHub organization or user owning the repo."
+}
+
+variable "github_repo" {
+  type        = string
+  default     = "arabic-voice-agent"
+  description = "GitHub repository name."
+}
+
+variable "state_bucket_name" {
+  type        = string
+  default     = "mishmish-tf-state"
+  description = "Terraform state bucket (referenced in the CI deploy policy)."
+}
+
+variable "tags" {
+  type = map(string)
+  default = {
+    Project = "arabic-voice-agent"
+  }
+  description = "Tags applied to all resources."
+}

--- a/aws/shared/versions.tf
+++ b/aws/shared/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.70"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Lands the Terraform rewrite of the CloudFormation infrastructure as **dormant code**. The existing CloudFormation stacks continue to deploy via the current workflows; this PR touches no workflows and no existing `aws/` files. A manual cutover (destroy CF, apply TF) is still required before TF becomes the source of truth — see `aws/README.md` and the approved migration plan for the runbook.

New layout:

- `aws/shared/` — env: VPC, ECR, IAM deploy role, EC2 instance profile
- `aws/shared/modules/{vpc,ecr-repo,github-actions-oidc-role,ec2-docker-host,cloudfront-site}/` — reusable modules
- `aws/prod/` — env: prod API EC2 + shared S3 + 2× CloudFront (web-app, admin-app)
- `aws/preview/` — env: shared preview EC2 + preview S3 + CloudFront + SPA-routing Function

Notes:

- State backend is S3-only with Terraform 1.10+ native locking (`use_lockfile = true`). No DynamoDB.
- Claude-agent is intentionally excluded; it will be decommissioned as part of cutover.
- All three envs pass `terraform fmt` and `terraform validate` (against 1.14.4).
- The CF `UserData` blocks are ported line-for-line into `userdata.sh.tftpl` with a `caddy_mode` conditional for prod vs. preview-empty.
- The new deploy policy drops `cloudformation:*` and `apprunner:*` and adds S3 state-bucket access; everything else (incl. `ec2:ModifyInstanceAttribute`) is preserved.

This PR can be merged safely — the new code is not referenced by any workflow. Cutover steps (bootstrap state bucket, destroy CF, apply TF locally, update DNS) still need to run with admin AWS creds.

## Test plan

- [x] `terraform fmt -recursive aws/` — clean
- [x] `terraform -chdir=aws/shared init -backend=false && terraform -chdir=aws/shared validate` — Success
- [x] `terraform -chdir=aws/prod init -backend=false && terraform -chdir=aws/prod validate` — Success
- [x] `terraform -chdir=aws/preview init -backend=false && terraform -chdir=aws/preview validate` — Success
- [ ] Manual cutover runs end-to-end (separate task, requires admin creds)
- [ ] Post-cutover PR swaps workflows from CF to TF and deletes `aws/bootstrap/`, `aws/prod/template.yaml`, `aws/preview/template.yaml`, `aws/claude-agent/`, and `.github/workflows/aws-sync-claude-agent.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)