### PR TITLE
fix: acm cert lookup + secretsmanager policy perm

### DIFF
--- a/aws/prod/variables.tf
+++ b/aws/prod/variables.tf
@@ -26,8 +26,8 @@ variable "api_domain" {
 
 variable "acm_certificate_domain" {
   type        = string
-  default     = "*.mishmish.ai"
-  description = "ACM certificate domain (looked up in us-east-1)."
+  default     = "mishmish.ai"
+  description = "ACM certificate primary domain (looked up in us-east-1; cert includes *.mishmish.ai SAN)."
 }
 
 variable "web_app_aliases" {

--- a/aws/shared/policies/github-actions-deploy.json.tftpl
+++ b/aws/shared/policies/github-actions-deploy.json.tftpl
@@ -247,6 +247,7 @@
       "Effect": "Allow",
       "Action": [
         "secretsmanager:DescribeSecret",
+        "secretsmanager:GetResourcePolicy",
         "secretsmanager:ListSecrets"
       ],
       "Resource": "*"


### PR DESCRIPTION
## Summary

Two small fixes discovered during the live cutover:

- `aws/prod/variables.tf`: the ACM certificate data source was looking up `*.mishmish.ai`, but the issued cert is registered under `mishmish.ai` (with `*.mishmish.ai` as a SAN). Switch to the primary domain.
- `aws/shared/policies/github-actions-deploy.json.tftpl`: add `secretsmanager:GetResourcePolicy` — Terraform calls this during refresh of `aws_secretsmanager_secret` data sources.

## Test plan

- [x] Re-applied `aws/shared` locally with the new policy
- [ ] Re-run `deploy-prod` workflow — expect apply to succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)