### PR TITLE
fix: add acm:GetCertificate to deploy role

### DIFF
--- a/aws/shared/policies/github-actions-deploy.json.tftpl
+++ b/aws/shared/policies/github-actions-deploy.json.tftpl
@@ -238,7 +238,9 @@
       "Effect": "Allow",
       "Action": [
         "acm:DescribeCertificate",
-        "acm:ListCertificates"
+        "acm:GetCertificate",
+        "acm:ListCertificates",
+        "acm:ListTagsForCertificate"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
Missing ACM perm surfaced during cutover `deploy-prod` run.