### PR TITLE
perf(web-app): defer Pipecat client until user starts a call

### DIFF
--- a/web-app/src/components/ActiveSession/ActiveSession.tsx
+++ b/web-app/src/components/ActiveSession/ActiveSession.tsx
@@ -1,15 +1,11 @@
 import { motion, AnimatePresence } from 'motion/react';
-import { useState } from 'react';
+import { lazy, Suspense, useState } from 'react';
 import { useStore } from '../../store';
 import { ChatView } from '../ChatView/ChatView';
-import { CallView } from '../CallView/CallView';
 import { Box, Flex, Spinner } from '@chakra-ui/react';
-import {
-  usePipecatClient,
-  usePipecatClientTransportState,
-} from '@pipecat-ai/client-react';
-import { useSupabase } from '@/context/SupabaseContext';
 import { useTranscriptMessages } from '@/hooks/useTranscriptMessages';
+
+const VoiceCall = lazy(() => import('../VoiceCall/VoiceCall'));
 
 const MotionBox = motion.create(Box);
 
@@ -37,77 +33,31 @@ export function ActiveSession() {
       w="full"
       h="full"
     >
-      <SessionContent viewMode={viewMode} setViewMode={setViewMode} />
+      <SessionContent
+        sessionId={activeSessionId}
+        viewMode={viewMode}
+        setViewMode={setViewMode}
+      />
     </MotionBox>
   );
 }
 
 function SessionContent({
+  sessionId,
   viewMode,
   setViewMode,
 }: {
+  sessionId: string;
   viewMode: ViewMode;
   setViewMode: (mode: ViewMode) => void;
 }) {
-  const supabase = useSupabase();
-  const client = usePipecatClient();
-  const transportState = usePipecatClientTransportState();
-  const activeSessionId = useStore((s) => s.session.activeSessionId);
   const messages = useStore((s) => s.session.messages);
-  const [voiceError, setVoiceError] = useState<string | null>(null);
 
   // Subscribe to transcript messages via Supabase Realtime
   useTranscriptMessages();
 
-  const isVoiceConnecting =
-    transportState === 'connecting' || transportState === 'initializing';
-  const isVoiceConnected = transportState === 'ready';
-
-  const handleStartCall = async () => {
-    // Immediately switch to call view
-    setViewMode('call');
-    setVoiceError(null);
-
-    // Connect to pipecat if not already connected
-    if (!isVoiceConnected && !isVoiceConnecting && client && activeSessionId) {
-      try {
-        const {
-          data: { session },
-        } = await supabase.auth.getSession();
-        if (!session?.access_token) {
-          setVoiceError('Authentication required');
-          return;
-        }
-
-        const { AppSettings } = await import('@/lib/app-settings');
-        const apiUrl = AppSettings.apiUrl;
-        const wsUrl = apiUrl.replace(/^http/, 'ws');
-
-        await client.connect({
-          wsUrl: `${wsUrl}/pipecat/session/${activeSessionId}?token=${encodeURIComponent(session.access_token)}`,
-        });
-      } catch (err) {
-        setVoiceError(
-          err instanceof Error ? err.message : 'Failed to connect voice'
-        );
-      }
-    }
-  };
-
-  const handleEndCall = async () => {
-    // Disconnect from pipecat
-    if (client && (isVoiceConnected || isVoiceConnecting)) {
-      try {
-        await client.disconnect();
-      } catch (err) {
-        console.error('Error disconnecting:', err);
-      }
-    }
-
-    // Switch back to chat view
-    setViewMode('chat');
-    setVoiceError(null);
-  };
+  const handleStartCall = () => setViewMode('call');
+  const handleEndCall = () => setViewMode('chat');
 
   return (
     <Flex direction="column" flex={1} minH={0}>
@@ -136,13 +86,15 @@ function SessionContent({
             display="flex"
             minH={0}
           >
-            <CallView
-              sessionId={activeSessionId}
-              isConnecting={isVoiceConnecting}
-              isConnected={isVoiceConnected}
-              error={voiceError}
-              onEndCall={handleEndCall}
-            />
+            <Suspense
+              fallback={
+                <Flex flex={1} align="center" justify="center">
+                  <Spinner size="xl" color="white" />
+                </Flex>
+              }
+            >
+              <VoiceCall sessionId={sessionId} onEndCall={handleEndCall} />
+            </Suspense>
           </MotionBox>
         )}
       </AnimatePresence>

--- a/web-app/src/components/VoiceCall/VoiceCall.tsx
+++ b/web-app/src/components/VoiceCall/VoiceCall.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react';
+import {
+  usePipecatClient,
+  usePipecatClientTransportState,
+} from '@pipecat-ai/client-react';
+import { PipecatProvider } from '@/providers/PipecatProvider';
+import { CallView } from '@/components/CallView/CallView';
+import { useSupabase } from '@/context/SupabaseContext';
+import { AppSettings } from '@/lib/app-settings';
+
+interface VoiceCallProps {
+  sessionId: string;
+  onEndCall: () => void;
+}
+
+function VoiceCallInner({ sessionId, onEndCall }: VoiceCallProps) {
+  const supabase = useSupabase();
+  const client = usePipecatClient();
+  const transportState = usePipecatClientTransportState();
+  const [voiceError, setVoiceError] = useState<string | null>(null);
+
+  const isVoiceConnecting =
+    transportState === 'connecting' || transportState === 'initializing';
+  const isVoiceConnected = transportState === 'ready';
+
+  useEffect(() => {
+    if (!client) return;
+    let cancelled = false;
+
+    const connect = async () => {
+      try {
+        const {
+          data: { session },
+        } = await supabase.auth.getSession();
+        if (cancelled) return;
+        if (!session?.access_token) {
+          setVoiceError('Authentication required');
+          return;
+        }
+
+        const wsUrl = AppSettings.apiUrl.replace(/^http/, 'ws');
+        await client.connect({
+          wsUrl: `${wsUrl}/pipecat/session/${sessionId}?token=${encodeURIComponent(session.access_token)}`,
+        });
+      } catch (err) {
+        if (!cancelled) {
+          setVoiceError(
+            err instanceof Error ? err.message : 'Failed to connect voice'
+          );
+        }
+      }
+    };
+
+    connect();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, supabase, sessionId]);
+
+  const handleEndCall = async () => {
+    if (client && (isVoiceConnected || isVoiceConnecting)) {
+      try {
+        await client.disconnect();
+      } catch (err) {
+        console.error('Error disconnecting:', err);
+      }
+    }
+    onEndCall();
+  };
+
+  return (
+    <CallView
+      sessionId={sessionId}
+      isConnecting={isVoiceConnecting}
+      isConnected={isVoiceConnected}
+      error={voiceError}
+      onEndCall={handleEndCall}
+    />
+  );
+}
+
+export default function VoiceCall(props: VoiceCallProps) {
+  return (
+    <PipecatProvider>
+      <VoiceCallInner {...props} />
+    </PipecatProvider>
+  );
+}

--- a/web-app/src/pages/HomePage.tsx
+++ b/web-app/src/pages/HomePage.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { Header } from '../components/Header';
 import { ActiveSession } from '../components/ActiveSession/ActiveSession';
-import { PipecatProvider } from '../providers/PipecatProvider';
 import { useStore } from '../store';
 import { Box, Flex } from '@chakra-ui/react';
 import { appGradient } from '@/lib/styles';
@@ -24,9 +23,7 @@ function HomePage() {
     >
       <Header />
       <Box flex={1} minH={0} pt="80px" px={{ base: 0, md: 6 }} pb={{ base: 4, md: 6 }} position="relative" zIndex={1}>
-        <PipecatProvider>
-          <ActiveSession />
-        </PipecatProvider>
+        <ActiveSession />
       </Box>
     </Flex>
   );


### PR DESCRIPTION
## Summary

- Split the Pipecat voice-call subtree (PipecatProvider + connect logic + CallView) into a new `VoiceCall` component and `React.lazy`-load it from `ActiveSession`
- Removed `PipecatProvider` from `HomePage` so the voice stack is no longer instantiated on every page load — it now loads only when the user clicks "start call"

## Why

`HomePage` wrapped all of its children in `PipecatProvider`, which instantiated a `PipecatClient` (WebSocket transport + protobuf serializer) on mount. That pulled the entire Pipecat client stack into the HomePage chunk for every visitor, including ones who never initiate a call — a significant contributor to the slow initial load at mishmish.ai.

This is one of five perf issues identified in an investigation of landing-page load time. Companion issues tracking the other four: [#143](https://github.com/tanyagray/arabic-voice-agent/issues/143), [#144](https://github.com/tanyagray/arabic-voice-agent/issues/144), [#145](https://github.com/tanyagray/arabic-voice-agent/issues/145), [#146](https://github.com/tanyagray/arabic-voice-agent/issues/146).

## Build impact

| Chunk | Before | After |
|---|---|---|
| HomePage | 772 KB (gzip 224 KB) | **312 KB (gzip 98 KB)** |
| VoiceCall (new, lazy) | — | 461 KB (gzip 126 KB) |

60% smaller HomePage critical path. The VoiceCall chunk only downloads when the user starts a call.

## What moved where

- New file: `web-app/src/components/VoiceCall/VoiceCall.tsx` — wraps `PipecatProvider` + handles connect on mount + renders `CallView`. Auto-connects using the Supabase access token, same logic that previously lived in `SessionContent.handleStartCall`.
- `web-app/src/components/ActiveSession/ActiveSession.tsx` — removed all `@pipecat-ai/*` imports, `useSupabase`, and `AppSettings` dynamic import; now `React.lazy`-loads `VoiceCall`. `ChatView` stays eager.
- `web-app/src/pages/HomePage.tsx` — removed the `<PipecatProvider>` wrap.

## Test plan

- [x] `npm run build` succeeds (TypeScript clean, chunk split confirmed above)
- [x] Dev-server initial-load network waterfall contains **no** `@pipecat-ai/*` modules
- [ ] Manual: click "start call", confirm mic enables, tutor responds, end call, reconnect works on a second call
- [ ] Manual: verify Supabase Realtime transcript updates still flow in both chat and call views
- [ ] Lighthouse before/after on the preview deploy — capture LCP / TBT deltas

End-to-end voice was not exercised in this branch because web-api isn't running locally. Recommend smoke-testing on the preview deploy before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)