### PR TITLE
feat: landing + onboarding flow with prompt admin editor

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -9,6 +9,13 @@
       "port": 5173
     },
     {
+      "name": "storybook",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", ". ~/.nvm/nvm.sh 2>/dev/null; npm run storybook -- --no-open"],
+      "cwd": "web-app",
+      "port": 6006
+    },
+    {
       "name": "admin-app",
       "runtimeExecutable": "bash",
       "runtimeArgs": ["-c", ". ~/.nvm/nvm.sh 2>/dev/null; npm run dev"],

--- a/admin-app/src/App.tsx
+++ b/admin-app/src/App.tsx
@@ -25,6 +25,7 @@ function App() {
                     <Routes>
                       <Route path="/" element={<Navigate to="/prompts/base" replace />} />
                       <Route path="/prompts" element={<Navigate to="/prompts/base" replace />} />
+                      <Route path="/prompts/flows/:flow/:step" element={<PromptEditPage />} />
                       <Route path="/prompts/:promptType" element={<PromptEditPage />} />
                       <Route path="/debug/chat" element={<ChatDebugPage />} />
                       <Route path="/debug/voice" element={<VoiceDebugPage />} />

--- a/admin-app/src/components/Layout.tsx
+++ b/admin-app/src/components/Layout.tsx
@@ -10,6 +10,24 @@ const PROMPT_ITEMS = [
   { label: 'Transliteration Prompt', path: '/prompts/transliteration' },
 ]
 
+type FlowGroup = {
+  label: string
+  basePath: string
+  steps: { label: string; path: string }[]
+}
+
+const FLOW_GROUPS: FlowGroup[] = [
+  {
+    label: 'Onboarding',
+    basePath: '/prompts/flows/onboarding',
+    steps: [
+      { label: 'Name', path: '/prompts/flows/onboarding/name' },
+      { label: 'Motivation', path: '/prompts/flows/onboarding/motivation' },
+      { label: 'Suggestions', path: '/prompts/flows/onboarding/suggestions' },
+    ],
+  },
+]
+
 const OTHER_NAV_ITEMS = [
   { label: 'Chat Debug', path: '/debug/chat' },
   { label: 'Voice Debug', path: '/debug/voice' },
@@ -19,8 +37,16 @@ export function Layout({ children }: { children: ReactNode }) {
   const { signOut } = useAuth()
   const navigate = useNavigate()
   const location = useLocation()
-  const isPromptsActive = location.pathname.startsWith('/prompts')
+  const isPromptsActive =
+    location.pathname.startsWith('/prompts') && !location.pathname.startsWith('/prompts/flows')
+  const isFlowsActive = location.pathname.startsWith('/prompts/flows')
   const [promptsOpen, setPromptsOpen] = useState(isPromptsActive)
+  const [flowsOpen, setFlowsOpen] = useState(isFlowsActive)
+  const [openFlows, setOpenFlows] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(
+      FLOW_GROUPS.map((g) => [g.basePath, location.pathname.startsWith(g.basePath)])
+    )
+  )
 
   async function handleSignOut() {
     await signOut()
@@ -33,6 +59,27 @@ export function Layout({ children }: { children: ReactNode }) {
       navigate('/prompts/base')
     } else {
       setPromptsOpen(false)
+    }
+  }
+
+  function handleFlowsClick() {
+    if (!flowsOpen) {
+      setFlowsOpen(true)
+      const first = FLOW_GROUPS[0]?.steps[0]
+      if (first) {
+        setOpenFlows((s) => ({ ...s, [FLOW_GROUPS[0].basePath]: true }))
+        navigate(first.path)
+      }
+    } else {
+      setFlowsOpen(false)
+    }
+  }
+
+  function handleFlowGroupClick(group: FlowGroup) {
+    const wasOpen = openFlows[group.basePath]
+    setOpenFlows((s) => ({ ...s, [group.basePath]: !wasOpen }))
+    if (!wasOpen) {
+      navigate(group.steps[0].path)
     }
   }
 
@@ -80,6 +127,76 @@ export function Layout({ children }: { children: ReactNode }) {
                   )}
                 </NavLink>
               ))}
+            </VStack>
+          )}
+
+          {/* Flows group */}
+          <Box
+            px={3}
+            py={2}
+            borderRadius="md"
+            bg={isFlowsActive && !flowsOpen ? 'blue.600' : 'transparent'}
+            _hover={{ bg: isFlowsActive ? undefined : 'gray.700' }}
+            cursor="pointer"
+            fontSize="sm"
+            fontWeight="semibold"
+            onClick={handleFlowsClick}
+            display="flex"
+            alignItems="center"
+            justifyContent="space-between"
+          >
+            Flows
+            <Text fontSize="xs" color="gray.400">{flowsOpen ? '▾' : '▸'}</Text>
+          </Box>
+
+          {flowsOpen && (
+            <VStack align="stretch" gap={0} pl={3}>
+              {FLOW_GROUPS.map((group) => {
+                const groupActive = location.pathname.startsWith(group.basePath)
+                const isOpen = !!openFlows[group.basePath]
+                return (
+                  <Box key={group.basePath}>
+                    <Box
+                      px={3}
+                      py={1.5}
+                      borderRadius="md"
+                      bg={groupActive && !isOpen ? 'blue.600' : 'transparent'}
+                      _hover={{ bg: groupActive && !isOpen ? undefined : 'gray.700' }}
+                      cursor="pointer"
+                      fontSize="sm"
+                      fontWeight="semibold"
+                      onClick={() => handleFlowGroupClick(group)}
+                      display="flex"
+                      alignItems="center"
+                      justifyContent="space-between"
+                    >
+                      {group.label}
+                      <Text fontSize="xs" color="gray.400">{isOpen ? '▾' : '▸'}</Text>
+                    </Box>
+                    {isOpen && (
+                      <VStack align="stretch" gap={0} pl={3}>
+                        {group.steps.map((step) => (
+                          <NavLink key={step.path} to={step.path}>
+                            {({ isActive }) => (
+                              <Box
+                                px={3}
+                                py={1.5}
+                                borderRadius="md"
+                                bg={isActive ? 'blue.600' : 'transparent'}
+                                _hover={{ bg: isActive ? 'blue.600' : 'gray.700' }}
+                                cursor="pointer"
+                                fontSize="sm"
+                              >
+                                {step.label}
+                              </Box>
+                            )}
+                          </NavLink>
+                        ))}
+                      </VStack>
+                    )}
+                  </Box>
+                )
+              })}
             </VStack>
           )}
 

--- a/admin-app/src/pages/PromptEditPage.tsx
+++ b/admin-app/src/pages/PromptEditPage.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState, useCallback } from 'react'
 import { useParams } from 'react-router-dom'
 import {
-  Alert, Badge, Box, Button, Flex, Heading, Textarea, Spinner
+  Alert, Badge, Box, Button, Dialog, Flex, Heading, IconButton, Portal,
+  Text, Textarea, Spinner, VStack,
 } from '@chakra-ui/react'
+import { FiTrash2 } from 'react-icons/fi'
 import apiClient from '../lib/api-client'
 import { useLanguage } from '../hooks/useLanguage'
 import { LanguageSelector } from '../components/LanguageSelector'
@@ -13,10 +15,63 @@ const PROMPT_TYPE_LABELS: Record<string, string> = {
   transliteration: 'Transliteration Prompt',
 }
 
-export function PromptEditPage() {
-  const { promptType } = useParams<{ promptType: string }>()
-  const { language, languages, loading: langLoading, setLanguage } = useLanguage()
+const FLOW_LABELS: Record<string, string> = {
+  onboarding: 'Onboarding',
+}
 
+type FlowSection = { key: 'prompt' | 'schema' | 'examples'; label: string; helper: string; minH: number }
+
+const FLOW_SECTIONS: FlowSection[] = [
+  {
+    key: 'prompt',
+    label: 'Prompt',
+    helper: 'Instructions sent to the model for this step. Supports placeholders like {name}, {text}.',
+    minH: 320,
+  },
+  {
+    key: 'schema',
+    label: 'Response Schema',
+    helper: 'JSON Schema the model response is validated against.',
+    minH: 220,
+  },
+  {
+    key: 'examples',
+    label: 'Examples',
+    helper: 'Few-shot examples the model can learn from. Stored as one markdown file, split on "### " headings.',
+    minH: 220,
+  },
+]
+
+/** Split a single examples.md file into one string per example. Splits on lines
+ *  that begin with "### " (markdown h3) so each entry keeps its own heading. If
+ *  the file has no h3 headings, the whole thing becomes a single example. */
+function parseExamples(content: string): string[] {
+  const trimmed = content.trim()
+  if (!trimmed) return []
+  if (!/^### /m.test(trimmed)) return [trimmed]
+  // Split so each resulting chunk starts with its own "### " heading.
+  const parts = trimmed.split(/(?=^### )/m).map((p) => p.trim()).filter(Boolean)
+  return parts.length > 0 ? parts : [trimmed]
+}
+
+function serializeExamples(examples: string[]): string {
+  const cleaned = examples.map((e) => e.trim()).filter(Boolean)
+  return cleaned.length === 0 ? '' : cleaned.join('\n\n') + '\n'
+}
+
+function titleCase(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+type SectionEditorProps = {
+  url: string
+  label: string
+  helper?: string
+  minH?: number
+  enabled: boolean
+}
+
+function SectionEditor({ url, label, helper, minH = 240, enabled }: SectionEditorProps) {
   const [content, setContent] = useState('')
   const [savedContent, setSavedContent] = useState('')
   const [loading, setLoading] = useState(true)
@@ -25,102 +80,323 @@ export function PromptEditPage() {
   const [successMsg, setSuccessMsg] = useState<string | null>(null)
 
   const hasChanges = content !== savedContent
-  const isPerLanguage = promptType === 'base'
 
-  const fetchPrompt = useCallback(async () => {
-    if (!promptType) return
-    if (isPerLanguage && !language) return
-
+  const fetchContent = useCallback(async () => {
+    if (!enabled) return
     setLoading(true)
     setError(null)
     setSuccessMsg(null)
-
-    const url = isPerLanguage
-      ? `/admin/prompts/base/${language}`
-      : `/admin/prompts/${promptType}`
-
     try {
       const res = await apiClient.get<{ content: string }>(url)
       setContent(res.data.content)
       setSavedContent(res.data.content)
     } catch {
-      setError('Failed to load prompt')
+      setError('Failed to load')
     } finally {
       setLoading(false)
     }
-  }, [promptType, language, isPerLanguage])
+  }, [url, enabled])
 
   useEffect(() => {
-    if (!langLoading) {
-      fetchPrompt()
-    }
-  }, [fetchPrompt, langLoading])
+    fetchContent()
+  }, [fetchContent])
 
   async function handleSave() {
-    if (!promptType) return
     setSaving(true)
     setError(null)
     setSuccessMsg(null)
-
-    const url = isPerLanguage
-      ? `/admin/prompts/base/${language}`
-      : `/admin/prompts/${promptType}`
-
     try {
       await apiClient.put(url, { content })
       setSavedContent(content)
-      setSuccessMsg('Saved successfully')
+      setSuccessMsg('Saved')
     } catch {
-      setError('Failed to save prompt')
+      setError('Failed to save')
     } finally {
       setSaving(false)
     }
   }
 
-  const title = PROMPT_TYPE_LABELS[promptType || ''] || 'Prompt'
-
-  if (langLoading) return <Box p={8}><Spinner /></Box>
-
   return (
-    <Box p={6} h="100%" display="flex" flexDirection="column">
-      <Flex align="center" gap={3} mb={4}>
-        <Heading size="md">
-          {title}
-          {hasChanges && <Badge ml={2} colorPalette="orange">Unsaved changes</Badge>}
+    <Box bg="white" borderRadius="md" borderWidth="1px" borderColor="gray.200" p={4}>
+      <Flex align="center" gap={3} mb={2}>
+        <Heading size="sm">
+          {label}
+          {hasChanges && <Badge ml={2} colorPalette="orange">Unsaved</Badge>}
         </Heading>
         <Box ml="auto" />
-        <LanguageSelector language={language} languages={languages} onChange={setLanguage} />
-        <Button colorPalette="blue" size="sm" onClick={handleSave} loading={saving} disabled={!hasChanges}>
+        <Button colorPalette="blue" size="xs" onClick={handleSave} loading={saving} disabled={!hasChanges}>
           Save
         </Button>
       </Flex>
-
+      {helper && (
+        <Text fontSize="xs" color="gray.500" mb={2}>{helper}</Text>
+      )}
       {error && (
-        <Alert.Root status="error" mb={3} borderRadius="md">
+        <Alert.Root status="error" mb={2} borderRadius="md" size="sm">
           <Alert.Description>{error}</Alert.Description>
         </Alert.Root>
       )}
       {successMsg && (
-        <Alert.Root status="success" mb={3} borderRadius="md">
+        <Alert.Root status="success" mb={2} borderRadius="md" size="sm">
+          <Alert.Description>{successMsg}</Alert.Description>
+        </Alert.Root>
+      )}
+      {loading ? (
+        <Box py={6}><Spinner size="sm" /></Box>
+      ) : (
+        <Textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          fontFamily="mono"
+          fontSize="sm"
+          resize="vertical"
+          minH={`${minH}px`}
+          bg="white"
+        />
+      )}
+    </Box>
+  )
+}
+
+type ExamplesEditorProps = {
+  url: string
+  label: string
+  helper?: string
+}
+
+function ExamplesEditor({ url, label, helper }: ExamplesEditorProps) {
+  const [examples, setExamples] = useState<string[]>([])
+  const [savedExamples, setSavedExamples] = useState<string[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [successMsg, setSuccessMsg] = useState<string | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<number | null>(null)
+
+  const hasChanges =
+    examples.length !== savedExamples.length ||
+    examples.some((e, i) => e !== savedExamples[i])
+
+  const fetchContent = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    setSuccessMsg(null)
+    try {
+      const res = await apiClient.get<{ content: string }>(url)
+      const parsed = parseExamples(res.data.content)
+      setExamples(parsed)
+      setSavedExamples(parsed)
+    } catch {
+      setError('Failed to load')
+    } finally {
+      setLoading(false)
+    }
+  }, [url])
+
+  useEffect(() => {
+    fetchContent()
+  }, [fetchContent])
+
+  async function handleSave() {
+    setSaving(true)
+    setError(null)
+    setSuccessMsg(null)
+    try {
+      const content = serializeExamples(examples)
+      await apiClient.put(url, { content })
+      setSavedExamples([...examples])
+      setSuccessMsg('Saved')
+    } catch {
+      setError('Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function updateExample(i: number, value: string) {
+    setExamples((prev) => prev.map((e, idx) => (idx === i ? value : e)))
+  }
+
+  function addExample() {
+    const nextNumber = examples.length + 1
+    const template = `### Example ${nextNumber} — \n`
+    setExamples((prev) => [...prev, template])
+  }
+
+  function confirmDelete(i: number) {
+    setExamples((prev) => prev.filter((_, idx) => idx !== i))
+    setPendingDelete(null)
+  }
+
+  return (
+    <Box bg="white" borderRadius="md" borderWidth="1px" borderColor="gray.200" p={4}>
+      <Flex align="center" gap={3} mb={2}>
+        <Heading size="sm">
+          {label}
+          {hasChanges && <Badge ml={2} colorPalette="orange">Unsaved</Badge>}
+        </Heading>
+        <Box ml="auto" />
+        <Button colorPalette="blue" size="xs" onClick={handleSave} loading={saving} disabled={!hasChanges}>
+          Save
+        </Button>
+      </Flex>
+      {helper && (
+        <Text fontSize="xs" color="gray.500" mb={3}>{helper}</Text>
+      )}
+      {error && (
+        <Alert.Root status="error" mb={2} borderRadius="md" size="sm">
+          <Alert.Description>{error}</Alert.Description>
+        </Alert.Root>
+      )}
+      {successMsg && (
+        <Alert.Root status="success" mb={2} borderRadius="md" size="sm">
           <Alert.Description>{successMsg}</Alert.Description>
         </Alert.Root>
       )}
 
       {loading ? (
-        <Box p={8}><Spinner /></Box>
+        <Box py={6}><Spinner size="sm" /></Box>
       ) : (
-        <Textarea
-          flex={1}
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          fontFamily="mono"
-          fontSize="sm"
-          resize="none"
-          h="100%"
-          minH="500px"
-          bg="white"
-        />
+        <VStack align="stretch" gap={3}>
+          {examples.length === 0 && (
+            <Text fontSize="sm" color="gray.500">No examples yet — add one below.</Text>
+          )}
+          {examples.map((ex, i) => (
+            <Box key={i} borderWidth="1px" borderColor="gray.200" borderRadius="md" p={3} bg="gray.50">
+              <Flex align="center" gap={2} mb={2}>
+                <Text fontSize="xs" color="gray.600" fontWeight="semibold">Example {i + 1}</Text>
+                <Box ml="auto" />
+                <IconButton
+                  aria-label={`Delete example ${i + 1}`}
+                  size="xs"
+                  variant="ghost"
+                  colorPalette="red"
+                  onClick={() => setPendingDelete(i)}
+                >
+                  <FiTrash2 />
+                </IconButton>
+              </Flex>
+              <Textarea
+                value={ex}
+                onChange={(e) => updateExample(i, e.target.value)}
+                fontFamily="mono"
+                fontSize="sm"
+                resize="vertical"
+                minH="160px"
+                bg="white"
+              />
+            </Box>
+          ))}
+          <Box>
+            <Button size="xs" variant="outline" onClick={addExample}>
+              + Add Example
+            </Button>
+          </Box>
+        </VStack>
       )}
+
+      <Dialog.Root
+        open={pendingDelete !== null}
+        onOpenChange={(e) => { if (!e.open) setPendingDelete(null) }}
+        role="alertdialog"
+      >
+        <Portal>
+          <Dialog.Backdrop />
+          <Dialog.Positioner>
+            <Dialog.Content>
+              <Dialog.Header>
+                <Dialog.Title>Delete example?</Dialog.Title>
+              </Dialog.Header>
+              <Dialog.Body>
+                <Text fontSize="sm">
+                  This removes example {pendingDelete !== null ? pendingDelete + 1 : ''} from the list.
+                  You'll still need to click <b>Save</b> for the change to be written to disk.
+                </Text>
+              </Dialog.Body>
+              <Dialog.Footer>
+                <Button variant="outline" size="sm" onClick={() => setPendingDelete(null)}>
+                  Cancel
+                </Button>
+                <Button
+                  colorPalette="red"
+                  size="sm"
+                  onClick={() => { if (pendingDelete !== null) confirmDelete(pendingDelete) }}
+                >
+                  Delete
+                </Button>
+              </Dialog.Footer>
+            </Dialog.Content>
+          </Dialog.Positioner>
+        </Portal>
+      </Dialog.Root>
+    </Box>
+  )
+}
+
+export function PromptEditPage() {
+  const { promptType, flow, step } = useParams<{ promptType?: string; flow?: string; step?: string }>()
+  const { language, languages, loading: langLoading, setLanguage } = useLanguage()
+
+  const isFlow = Boolean(flow && step)
+  const isPerLanguage = !isFlow && promptType === 'base'
+
+  if (langLoading) return <Box p={8}><Spinner /></Box>
+
+  // Flow mode — stacked sections (prompt / schema / examples)
+  if (isFlow) {
+    const title = `${FLOW_LABELS[flow!] ?? titleCase(flow!)} · ${titleCase(step!)}`
+    return (
+      <Box p={6} h="100%" display="flex" flexDirection="column">
+        <Flex align="center" gap={3} mb={4}>
+          <Heading size="md">{title}</Heading>
+        </Flex>
+        <VStack align="stretch" gap={4}>
+          {FLOW_SECTIONS.map((s) => {
+            const url = `/admin/prompts/flows/${flow}/${step}/${s.key}`
+            if (s.key === 'examples') {
+              return (
+                <ExamplesEditor key={s.key} url={url} label={s.label} helper={s.helper} />
+              )
+            }
+            return (
+              <SectionEditor
+                key={s.key}
+                url={url}
+                label={s.label}
+                helper={s.helper}
+                minH={s.minH}
+                enabled
+              />
+            )
+          })}
+        </VStack>
+      </Box>
+    )
+  }
+
+  // Regular single-section mode
+  const title = PROMPT_TYPE_LABELS[promptType || ''] || 'Prompt'
+  const promptUrl = isPerLanguage
+    ? `/admin/prompts/base/${language}`
+    : `/admin/prompts/${promptType}`
+  const enabled = isPerLanguage ? Boolean(language) : Boolean(promptType)
+
+  return (
+    <Box p={6} h="100%" display="flex" flexDirection="column">
+      <Flex align="center" gap={3} mb={4}>
+        <Heading size="md">{title}</Heading>
+        <Box ml="auto" />
+        {isPerLanguage && (
+          <LanguageSelector language={language} languages={languages} onChange={setLanguage} />
+        )}
+      </Flex>
+      <SectionEditor
+        key={promptUrl}
+        url={promptUrl}
+        label={title}
+        minH={500}
+        enabled={enabled}
+      />
     </Box>
   )
 }

--- a/web-api/agent/tutor/prompts/flows/onboarding/motivation/examples.md
+++ b/web-api/agent/tutor/prompts/flows/onboarding/motivation/examples.md
@@ -1,0 +1,19 @@
+### Example 1 — travel
+context: name=Salma
+user: i'm going to Cairo in the summer and i don't want to feel helpless
+agent: { "acknowledgement": "mumtaz! Cairo in summer deserves real Arabic — we'll get you ready.", "motivation_tag": "travel to Cairo" }
+
+### Example 2 — heritage
+context: name=Omar
+user: my grandparents spoke it and i never learned. i want to reconnect
+agent: { "acknowledgement": "that's such a rich reason, Omar — we'll honour it together.", "motivation_tag": "family heritage" }
+
+### Example 3 — curiosity / short
+context: name=Priya
+user: idk, just curious
+agent: { "acknowledgement": "perfect — curiosity is the best place to start, Priya.", "motivation_tag": "general curiosity" }
+
+### Example 4 — Quran
+context: name=Yusuf
+user: i want to read the Quran in the original language
+agent: { "acknowledgement": "beautiful, Yusuf — we'll build up to classical script together.", "motivation_tag": "reading the Quran" }

--- a/web-api/agent/tutor/prompts/flows/onboarding/motivation/prompt.md
+++ b/web-api/agent/tutor/prompts/flows/onboarding/motivation/prompt.md
@@ -1,0 +1,14 @@
+You are Mishmish, guiding a new learner through onboarding. On this step the user has just shared why they're curious about Arabic. Your goal is to acknowledge their reason warmly and summarise it in a single short phrase that can steer later lesson suggestions.
+
+## Context
+The user is on the onboarding "motivation" step. They've just answered the prompt "tell me, why are you curious to learn arabii?". Replies will vary wildly — family heritage, a partner, travel, reading the Quran, work, idle curiosity, etc. Some users will write essays; others will answer in three words.
+
+## Rules
+- Be genuinely warm and specific — reflect back what they said rather than generic "that's nice".
+- Keep the acknowledgement to a single short line. No monologues.
+- Extract a concise motivation tag (2–4 words) that captures the intent — this will be used to pick starter lessons.
+- If the reply is off-topic or empty, pick a sensible default tag ("general curiosity") and acknowledge without judgement.
+- Always use the learner's name when it is known.
+
+Learner's name: {name}
+User reply: {text}

--- a/web-api/agent/tutor/prompts/flows/onboarding/motivation/schema.md
+++ b/web-api/agent/tutor/prompts/flows/onboarding/motivation/schema.md
@@ -1,0 +1,19 @@
+```json
+{
+  "type": "object",
+  "required": ["acknowledgement", "motivation_tag"],
+  "properties": {
+    "acknowledgement": {
+      "type": "string",
+      "description": "One short line reflecting back what the learner said, e.g. 'mumtaz! Egyptian films will take you far.'"
+    },
+    "motivation_tag": {
+      "type": "string",
+      "description": "A concise 2–4 word summary of the motivation, used by downstream steps to pick starter lessons.",
+      "minLength": 1,
+      "maxLength": 60
+    }
+  },
+  "additionalProperties": false
+}
+```

--- a/web-api/agent/tutor/prompts/flows/onboarding/name/examples.md
+++ b/web-api/agent/tutor/prompts/flows/onboarding/name/examples.md
@@ -1,0 +1,15 @@
+### Example 1 — plain name
+user: Salma
+agent: { "name": "Salma", "greeting": "ahlan ya Salma!" }
+
+### Example 2 — full sentence
+user: my name is Ahmed, nice to meet you
+agent: { "name": "Ahmed", "greeting": "ahlan ya Ahmed!" }
+
+### Example 3 — decline to share
+user: i'd rather not say
+agent: { "name": null, "greeting": "ahlan ya habibi!" }
+
+### Example 4 — ambiguous / nickname
+user: everyone calls me Sam
+agent: { "name": "Sam", "greeting": "ahlan ya Sam!" }

--- a/web-api/agent/tutor/prompts/flows/onboarding/name/prompt.md
+++ b/web-api/agent/tutor/prompts/flows/onboarding/name/prompt.md
@@ -1,0 +1,14 @@
+You are Mishmish, a warm Arabic tutor meeting a new learner for the first time. Your goal on this step is to welcome them and extract their name from whatever they reply.
+
+## Context
+The user has just typed a response to the prompt "what is your name?" on the onboarding landing page. They may reply with just a name, a full sentence ("my name is Salma"), a hedge ("I don't really want to say"), or something off-topic.
+
+## Rules
+- Greet the learner warmly but briefly — they just arrived.
+- Extract the most likely name from the reply. If the reply is ambiguous, make a best guess rather than asking again.
+- If the user clearly declines to share a name, fall back to a friendly neutral address ("friend", "habibi", etc.) — do not pressure them.
+- Never invent a name that wasn't plausibly in the reply.
+- Reply in a warm, concise tone. Mix in a single Arabic word only if it feels natural.
+
+User reply:
+{text}

--- a/web-api/agent/tutor/prompts/flows/onboarding/name/schema.md
+++ b/web-api/agent/tutor/prompts/flows/onboarding/name/schema.md
@@ -1,0 +1,17 @@
+```json
+{
+  "type": "object",
+  "required": ["name", "greeting"],
+  "properties": {
+    "name": {
+      "type": ["string", "null"],
+      "description": "The learner's extracted name, or null if none could be extracted from the reply."
+    },
+    "greeting": {
+      "type": "string",
+      "description": "One short line to display on the next step, e.g. 'ahlan ya Salma!' — uses the extracted name when available, otherwise a neutral address."
+    }
+  },
+  "additionalProperties": false
+}
+```

--- a/web-api/agent/tutor/prompts/flows/onboarding/suggestions/examples.md
+++ b/web-api/agent/tutor/prompts/flows/onboarding/suggestions/examples.md
@@ -1,0 +1,9 @@
+### Example 1 — traveller
+context: name=Salma, motivation_tag=travel to Cairo
+user: i'm going to Cairo in the summer
+agent: { "intro": "mumtaz! Cairo is waiting — where shall we begin?", "tiles": [ { "level": "Beginner", "title": "Your first 10 Cairo words", "blurb": "Greetings, 'shukran', asking for water — enough to feel brave on day one.", "arabic": "شكراً" }, { "level": "Intermediate", "title": "Café in Cairo", "blurb": "Role-play ordering qahwa, small talk, asking for the bill — realistic and fun.", "arabic": "قهوة" }, { "level": "Advanced", "title": "Haggling at Khan el-Khalili", "blurb": "Numbers, negotiation phrases, polite stubbornness — leave with a story.", "arabic": "خان الخليلي" } ] }
+
+### Example 2 — heritage
+context: name=Omar, motivation_tag=family heritage
+user: my grandparents spoke it and i never learned
+agent: { "intro": "beautiful reason, Omar. where shall we begin?", "tiles": [ { "level": "Beginner", "title": "Family words that stick", "blurb": "Mama, baba, tayta, jiddo — the vocabulary you already half-know.", "arabic": "عائلة" }, { "level": "Intermediate", "title": "Sunday phone call", "blurb": "Ask about the weather, the kids, the food — rehearse a call with tayta.", "arabic": "تيتا" }, { "level": "Advanced", "title": "Your grandparents' stories", "blurb": "Past-tense verbs and storytelling vocabulary — record a conversation.", "arabic": "حكاية" } ] }

--- a/web-api/agent/tutor/prompts/flows/onboarding/suggestions/prompt.md
+++ b/web-api/agent/tutor/prompts/flows/onboarding/suggestions/prompt.md
@@ -1,0 +1,14 @@
+You are Mishmish, helping a new learner choose their first lesson. Using the learner's name and motivation, propose three starter options tuned to their reason for learning — one beginner, one intermediate, one advanced.
+
+## Context
+The user has completed the "name" and "motivation" steps of onboarding. They are now looking at a page that will show three lesson tiles plus a free-text input. Your job is to produce the content for those tiles and a one-line intro.
+
+## Rules
+- Tailor each tile to the motivation when possible. Café role-plays for a traveller, script practice for a Quran learner, news headlines for a political-science student, etc.
+- Each tile needs: a level label ("Beginner" | "Intermediate" | "Advanced"), a short title (3–6 words), a one-sentence blurb, and an optional single Arabic word/phrase that previews the lesson.
+- Keep tone warm, concrete, low-pressure. No "level up your Arabic!" marketing voice.
+- The intro line should acknowledge the motivation in one short phrase and invite the learner to pick.
+
+Learner's name: {name}
+Motivation tag: {motivation_tag}
+Raw motivation reply: {motivation_text}

--- a/web-api/agent/tutor/prompts/flows/onboarding/suggestions/schema.md
+++ b/web-api/agent/tutor/prompts/flows/onboarding/suggestions/schema.md
@@ -1,0 +1,35 @@
+```json
+{
+  "type": "object",
+  "required": ["intro", "tiles"],
+  "properties": {
+    "intro": {
+      "type": "string",
+      "description": "One short line that acknowledges the motivation and invites the learner to pick, e.g. 'mumtaz! that\u2019s a great reason to learn. where shall we begin?'"
+    },
+    "tiles": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": ["level", "title", "blurb"],
+        "properties": {
+          "level": {
+            "type": "string",
+            "enum": ["Beginner", "Intermediate", "Advanced"]
+          },
+          "title": { "type": "string", "minLength": 1, "maxLength": 60 },
+          "blurb": { "type": "string", "minLength": 1, "maxLength": 160 },
+          "arabic": {
+            "type": ["string", "null"],
+            "description": "Optional single Arabic word/phrase previewing the lesson."
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}
+```

--- a/web-api/channels/rest/routes/admin.py
+++ b/web-api/channels/rest/routes/admin.py
@@ -138,6 +138,73 @@ async def update_transliteration_prompt(
     return PromptContent(content=body.content)
 
 
+# ── Flow prompts ──────────────────────────────────────────────────────────────
+# Flow prompts live under agent/tutor/prompts/flows/<flow>/<step>/<section>.md,
+# where section ∈ {prompt, schema, examples}. One pair of endpoints handles all
+# flows/steps/sections so adding a new step only requires dropping in markdown
+# files.
+
+FLOWS_DIR = PROMPTS_DIR / "flows"
+
+_FLOW_NAME_PATTERN = "[A-Za-z0-9_-]+"
+_ALLOWED_SECTIONS = {"prompt", "schema", "examples"}
+
+
+def _resolve_flow_prompt_path(flow: str, step: str, section: str) -> Path:
+    """Resolve a flow prompt section path, guarding against traversal."""
+    import re
+    if not re.fullmatch(_FLOW_NAME_PATTERN, flow) or not re.fullmatch(_FLOW_NAME_PATTERN, step):
+        raise HTTPException(status_code=400, detail="Invalid flow or step identifier")
+    if section not in _ALLOWED_SECTIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid section '{section}'. Expected one of: {sorted(_ALLOWED_SECTIONS)}",
+        )
+    path = FLOWS_DIR / flow / step / f"{section}.md"
+    # Ensure the resolved path is still inside FLOWS_DIR
+    try:
+        path.resolve().relative_to(FLOWS_DIR.resolve())
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid flow path")
+    return path
+
+
+@router.get("/prompts/flows/{flow}/{step}/{section}")
+async def get_flow_prompt_section(
+    flow: str,
+    step: str,
+    section: str,
+    _: str = Depends(get_admin_user),
+) -> PromptContent:
+    """Return the markdown content of a flow-step-section file."""
+    path = _resolve_flow_prompt_path(flow, step, section)
+    if not path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail=f"Flow prompt not found: {flow}/{step}/{section}",
+        )
+    return PromptContent(content=path.read_text(encoding="utf-8"))
+
+
+@router.put("/prompts/flows/{flow}/{step}/{section}")
+async def update_flow_prompt_section(
+    flow: str,
+    step: str,
+    section: str,
+    body: PromptContent,
+    _: str = Depends(get_admin_user),
+) -> PromptContent:
+    """Overwrite a flow-step-section file."""
+    path = _resolve_flow_prompt_path(flow, step, section)
+    if not path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail=f"Flow prompt not found: {flow}/{step}/{section}",
+        )
+    path.write_text(body.content, encoding="utf-8")
+    return PromptContent(content=body.content)
+
+
 # ── Admin chat sessions ───────────────────────────────────────────────────────
 
 # In-memory store for admin sessions (separate from user sessions)

--- a/web-app/.storybook/preview.tsx
+++ b/web-app/.storybook/preview.tsx
@@ -32,17 +32,20 @@ const preview: Preview = {
     }
   },
   decorators: [
-    (Story) => (
-      <SupabaseProvider>
-        <AuthProvider>
-          <MemoryRouter>
-            <ChakraProvider value={system}>
-              <Story />
-            </ChakraProvider>
-          </MemoryRouter>
-        </AuthProvider>
-      </SupabaseProvider>
-    ),
+    (Story, context) => {
+      const initialEntries = (context.parameters?.initialEntries as string[] | undefined) ?? ['/'];
+      return (
+        <ChakraProvider value={system}>
+          <SupabaseProvider>
+            <AuthProvider>
+              <MemoryRouter initialEntries={initialEntries}>
+                <Story />
+              </MemoryRouter>
+            </AuthProvider>
+          </SupabaseProvider>
+        </ChakraProvider>
+      );
+    },
     withThemeByClassName({
       defaultTheme: "light",
       themes: { light: "", dark: "dark" },

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -7,6 +7,8 @@ import { LoadingSpinner } from './components/LoadingSpinner';
 
 // Lazy load pages
 const HomePage = lazy(() => import('./pages/HomePage'));
+const Landing = lazy(() => import('./pages/Landing'));
+const Onboarding = lazy(() => import('./pages/Onboarding'));
 const SignIn = lazy(() => import('./pages/auth/SignIn'));
 const VerifyEmail = lazy(() => import('./pages/auth/VerifyEmail'));
 const ForgotPassword = lazy(() => import('./pages/auth/ForgotPassword'));
@@ -29,6 +31,11 @@ function App() {
   return (
     <Suspense fallback={<LoadingSpinner />}>
       <Routes>
+        <Route path="/landing" element={<Landing />} />
+        <Route path="/onboarding" element={<Onboarding />} />
+        <Route path="/onboarding/name" element={<Onboarding />} />
+        <Route path="/onboarding/motivation" element={<Onboarding />} />
+        <Route path="/onboarding/suggestions" element={<Onboarding />} />
         {/* Main app routes */}
         <Route path="/" element={<HomePage />} />
         <Route path="/settings" element={<SettingsPage />} />

--- a/web-app/src/pages/Landing.stories.tsx
+++ b/web-app/src/pages/Landing.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Landing from './Landing';
+
+const meta = {
+  title: 'Pages/Landing',
+  component: Landing,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof Landing>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ReturningUser: Story = {
+  args: { userState: 'returning', color: 'apricot' },
+};

--- a/web-app/src/pages/Landing.tsx
+++ b/web-app/src/pages/Landing.tsx
@@ -1,0 +1,749 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type SVGProps } from 'react';
+import { useStore } from '@/store';
+import { useTranscriptMessages } from '@/hooks/useTranscriptMessages';
+import { useSupabase } from '@/context/SupabaseContext';
+import type { TranscriptMessage, ResponseMode } from '@/api/sessions/sessions.types';
+
+export type ThemeKey = 'apricot' | 'dark';
+type UserState = 'new' | 'returning';
+
+export type Theme = {
+  bg: string;
+  surface: string;
+  ink: string;
+  sub: string;
+  border: string;
+  tint: string;
+  tintDeep: string;
+  tintSoft: string;
+  highlight: string;
+  isDark: boolean;
+};
+
+export const THEMES: Record<ThemeKey, Theme> = {
+  apricot: {
+    bg: '#FBF6EC',
+    surface: '#FFFFFF',
+    ink: '#2A1D12',
+    sub: '#6E5A46',
+    border: '#EADFC9',
+    tint: '#E87E3C',
+    tintDeep: '#C35A1C',
+    tintSoft: '#FCE8CF',
+    highlight: '#FFE8CC',
+    isDark: false,
+  },
+  dark: {
+    bg: '#141012',
+    surface: '#1E1819',
+    ink: '#F6EFE5',
+    sub: '#9A8E80',
+    border: '#2E2624',
+    tint: '#F19248',
+    tintDeep: '#E87E3C',
+    tintSoft: 'rgba(241,146,72,0.15)',
+    highlight: 'rgba(241,146,72,0.22)',
+    isDark: true,
+  },
+};
+
+export const FONT_STACK = "'Noto Sans Arabic', 'Inter', system-ui, sans-serif";
+
+const Icon = {
+  mic: (p: SVGProps<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" {...p}>
+      <rect x="9" y="3" width="6" height="12" rx="3" />
+      <path d="M5 11a7 7 0 0 0 14 0" />
+      <path d="M12 18v3" />
+    </svg>
+  ),
+  play: (p: SVGProps<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" fill="currentColor" {...p}><path d="M8 5v14l11-7z" /></svg>
+  ),
+  send: (p: SVGProps<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" {...p}>
+      <path d="M21 3 11 13" />
+      <path d="M21 3 14.5 21l-3.5-8-8-3.5L21 3z" />
+    </svg>
+  ),
+  user: (p: SVGProps<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" {...p}>
+      <circle cx="12" cy="8" r="4" />
+      <path d="M4 21c1.5-4 5-6 8-6s6.5 2 8 6" />
+    </svg>
+  ),
+  settings: (p: SVGProps<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" {...p}>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z" />
+    </svg>
+  ),
+};
+
+function ApricotMark({ size = 26 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40">
+      <defs>
+        <radialGradient id="apr-body-2" cx="35%" cy="30%" r="75%">
+          <stop offset="0%" stopColor="#FFD199" />
+          <stop offset="55%" stopColor="#F09B53" />
+          <stop offset="100%" stopColor="#B8501A" />
+        </radialGradient>
+      </defs>
+      <path d="M20 9 C12 9 6 15 6 23 C6 31 12 36 20 36 C28 36 34 31 34 23 C34 15 28 9 20 9 Z" fill="url(#apr-body-2)" />
+      <path d="M20 10 C19 14 19 30 20 36" stroke="rgba(155,63,16,0.35)" strokeWidth="1" fill="none" />
+      <path d="M20 10 C18 5 14 3 10 4 C11 8 15 11 20 10 Z" fill="#5DA34D" />
+      <ellipse cx="14" cy="17" rx="3.5" ry="2" fill="rgba(255,255,255,0.4)" />
+    </svg>
+  );
+}
+
+type TextSegment = { text: string; color: string };
+type ChipSegment = { chip: { ar: string; latin: string; meaning: string } };
+type Segment = TextSegment | ChipSegment;
+
+const isChip = (s: Segment): s is ChipSegment => 'chip' in s;
+const segLen = (s: Segment): number => (isChip(s) ? 1 : [...s.text].length);
+const totalChars = (segs: Segment[]): number => segs.reduce((n, s) => n + segLen(s), 0);
+
+const CPS = 32;
+const LINE_GAP = 800;
+
+function FadeSlide({ show, children, delay = 0 }: { show: boolean; children: React.ReactNode; delay?: number }) {
+  return (
+    <div style={{
+      opacity: show ? 1 : 0,
+      transform: show ? 'translateY(0)' : 'translateY(18px)',
+      transition: `opacity 0.7s cubic-bezier(.2,.7,.3,1) ${delay}ms, transform 0.7s cubic-bezier(.2,.7,.3,1) ${delay}ms`,
+      willChange: 'transform, opacity',
+    }}>{children}</div>
+  );
+}
+
+export function UserInput({ theme, isMobile, prefilled = null, autoFocus = true, onSubmit, onMicClick, disabled = false }: {
+  theme: Theme; isMobile: boolean; prefilled?: string | null; autoFocus?: boolean;
+  onSubmit: (msg: string) => void; onMicClick?: () => void; disabled?: boolean;
+}) {
+  const [value, setValue] = useState(prefilled || '');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (autoFocus) {
+      const t = setTimeout(() => inputRef.current?.focus(), 50);
+      return () => clearTimeout(t);
+    }
+  }, [autoFocus]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const msg = value.trim();
+    if (!msg || disabled) return;
+    onSubmit(msg);
+    setValue('');
+    inputRef.current?.focus();
+  };
+
+  const handleMicClick = () => {
+    if (onMicClick) onMicClick();
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      style={{
+        marginTop: isMobile ? 4 : 8, background: theme.surface,
+        border: `1.5px solid ${theme.tint}`,
+        borderRadius: isMobile ? 18 : 22, padding: isMobile ? '16px 16px' : '22px 24px',
+        display: 'flex', alignItems: 'center', gap: 14,
+        boxShadow: `0 20px 40px -24px ${theme.tint}66, 0 0 0 4px ${theme.tintSoft}`,
+      }}
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        autoComplete="off"
+        style={{
+          flex: 1, minWidth: 0,
+          fontFamily: FONT_STACK,
+          fontSize: isMobile ? 26 : 40, color: theme.ink,
+          lineHeight: 1.1, letterSpacing: '-0.02em',
+          fontWeight: 600,
+          background: 'transparent', border: 'none', outline: 'none',
+          caretColor: theme.tint,
+        }}
+      />
+      {value.trim() ? (
+        <button
+          type="submit"
+          aria-label="Send message"
+          style={{
+            width: isMobile ? 44 : 54, height: isMobile ? 44 : 54, borderRadius: '50%',
+            background: theme.tint, color: '#fff', border: 'none', cursor: 'pointer',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+            boxShadow: `0 8px 24px -6px ${theme.tint}88`,
+          }}
+        >
+          <Icon.send width={isMobile ? 18 : 22} height={isMobile ? 18 : 22} />
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={handleMicClick}
+          aria-label="Start voice call"
+          style={{
+            width: isMobile ? 44 : 54, height: isMobile ? 44 : 54, borderRadius: '50%',
+            background: theme.tint, color: '#fff', border: 'none', cursor: 'pointer',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+            boxShadow: `0 8px 24px -6px ${theme.tint}88`,
+          }}
+        >
+          <Icon.mic width={isMobile ? 18 : 22} height={isMobile ? 18 : 22} />
+        </button>
+      )}
+    </form>
+  );
+}
+
+function ArabicChip({ ar, latin, meaning, theme }: { ar: string; latin: string; meaning: string; theme: Theme }) {
+  const [hover, setHover] = useState(false);
+  return (
+    <span
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onClick={() => setHover((v) => !v)}
+      style={{
+        position: 'relative',
+        background: theme.highlight,
+        borderRadius: 6,
+        padding: '0 6px',
+        cursor: 'pointer',
+        color: theme.tintDeep,
+        display: 'inline-block',
+        lineHeight: 1.1,
+      }}>
+      {latin}
+      <span style={{
+        position: 'absolute', left: '50%', bottom: '100%',
+        transform: `translate(-50%, ${hover ? '-6px' : '0'})`,
+        opacity: hover ? 1 : 0, pointerEvents: 'none',
+        transition: 'all .22s cubic-bezier(.2,.7,.3,1)',
+        background: theme.ink, color: theme.bg,
+        padding: '8px 12px', borderRadius: 10, whiteSpace: 'nowrap',
+        fontFamily: FONT_STACK, fontStyle: 'normal', fontWeight: 500,
+        fontSize: 13, letterSpacing: '-0.01em',
+        boxShadow: '0 10px 24px -8px rgba(0,0,0,0.3)', zIndex: 5,
+      }}>
+        <span style={{
+          fontFamily: 'Noto Sans Arabic, serif', direction: 'rtl',
+          fontSize: 18, marginRight: 8, color: theme.tint,
+        }}>{ar}</span>
+        <span style={{ opacity: 0.75 }}>— {meaning}</span>
+      </span>
+    </span>
+  );
+}
+
+function groupBySource(messages: TranscriptMessage[]): TranscriptMessage[][] {
+  const groups: TranscriptMessage[][] = [];
+  for (const m of messages) {
+    const last = groups[groups.length - 1];
+    if (last && last[0].message_source === m.message_source) last.push(m);
+    else groups.push([m]);
+  }
+  return groups;
+}
+
+function getTutorDisplayText(m: TranscriptMessage, mode: ResponseMode): string {
+  if (mode === 'canonical' && m.message_text_canonical) return m.message_text_canonical;
+  if (mode === 'transliterated' && m.message_text_transliterated) return m.message_text_transliterated;
+  if (mode === 'scaffolded' && m.message_text_scaffolded) return m.message_text_scaffolded;
+  return m.message_text;
+}
+
+export function ChatMessages({ theme, isMobile, messages, responseMode }: {
+  theme: Theme; isMobile: boolean; messages: TranscriptMessage[]; responseMode: ResponseMode;
+}) {
+  const filtered = messages.filter(
+    (m) => (m.message_kind === 'text' || m.message_kind === 'audio') && m.message_source !== 'system'
+  );
+  if (filtered.length === 0) return null;
+  const groups = groupBySource(filtered);
+  const bigR = 20;
+  const smallR = 6;
+  const fontSize = isMobile ? 17 : 19;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: isMobile ? 10 : 12 }}>
+      {groups.map((group) => {
+        const isUser = group[0].message_source === 'user';
+        return (
+          <div
+            key={group[0].message_id}
+            style={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+          >
+            {group.map((m, i) => {
+              const isFirst = i === 0;
+              const isLast = i === group.length - 1;
+              const displayText = isUser ? m.message_text : getTutorDisplayText(m, responseMode);
+              const isRtl = !isUser && responseMode === 'canonical';
+              // Tail is on the side of the sender; flatten corner on tail side when grouped
+              const topRight = isUser ? (isFirst ? bigR : smallR) : bigR;
+              const topLeft = !isUser ? (isFirst ? bigR : smallR) : bigR;
+              const bottomRight = isUser ? (isLast ? smallR : smallR) : bigR;
+              const bottomLeft = !isUser ? (isLast ? smallR : smallR) : bigR;
+              return (
+                <div
+                  key={m.message_id}
+                  style={{
+                    display: 'flex',
+                    justifyContent: isUser ? 'flex-end' : 'flex-start',
+                  }}
+                >
+                  <div
+                    dir={isRtl ? 'rtl' : undefined}
+                    style={{
+                      maxWidth: '80%',
+                      padding: isMobile ? '10px 14px' : '12px 16px',
+                      background: isUser ? theme.tint : theme.surface,
+                      color: isUser ? '#fff' : theme.ink,
+                      border: isUser ? 'none' : `1px solid ${theme.border}`,
+                      borderTopRightRadius: topRight,
+                      borderTopLeftRadius: topLeft,
+                      borderBottomRightRadius: bottomRight,
+                      borderBottomLeftRadius: bottomLeft,
+                      fontFamily: FONT_STACK,
+                      fontSize,
+                      fontWeight: 500,
+                      lineHeight: 1.4,
+                      letterSpacing: '-0.01em',
+                      whiteSpace: 'pre-wrap',
+                      wordBreak: 'break-word',
+                    }}
+                  >
+                    {displayText}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function NewUserHero({ theme, isMobile, messages, responseMode, onSubmit, onMicClick, inputDisabled }: {
+  theme: Theme; isMobile: boolean; messages: TranscriptMessage[]; responseMode: ResponseMode;
+  onSubmit: (msg: string) => void; onMicClick: () => void; inputDisabled: boolean;
+}) {
+  const LINES: Segment[][] = useMemo(() => [
+    [{ text: 'marhaban!', color: theme.tint }],
+    [
+      { text: "i'm ", color: theme.ink },
+      { text: 'mishmish', color: theme.tint },
+      { text: ', which means apricot \uD83D\uDE0A', color: theme.ink },
+    ],
+    [{ text: 'what is your name?', color: theme.ink }],
+  ], [theme.tint, theme.ink]);
+
+  const [counts, setCounts] = useState([0, 0, 0]);
+  const [activeLine, setActiveLine] = useState(-1);
+  const [showInput, setShowInput] = useState(false);
+  const rafRef = useRef<number | undefined>(undefined);
+
+  const run = useCallback(() => {
+    setCounts([0, 0, 0]);
+    setActiveLine(-1);
+    setShowInput(false);
+    const startAt = performance.now() + 150;
+    const lineDur = LINES.map((l) => (totalChars(l) / CPS) * 1000);
+    const lineStart: number[] = [];
+    for (let i = 0; i < LINES.length; i++) {
+      lineStart[i] = i === 0 ? startAt : lineStart[i - 1] + lineDur[i - 1] + LINE_GAP;
+    }
+
+    const tick = (now: number) => {
+      const next = LINES.map((l, i) => {
+        const t = now - lineStart[i];
+        if (t <= 0) return 0;
+        return Math.min(totalChars(l), Math.floor((t / 1000) * CPS));
+      });
+      setCounts(next);
+
+      let active = -1;
+      for (let i = 0; i < LINES.length; i++) {
+        if (now >= lineStart[i]) active = i;
+      }
+      setActiveLine(active);
+
+      const lastEnd = lineStart[LINES.length - 1] + lineDur[LINES.length - 1];
+      if (now < lastEnd + 600) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        setActiveLine(-1);
+        setTimeout(() => setShowInput(true), 200);
+      }
+    };
+    rafRef.current = requestAnimationFrame(tick);
+  }, [LINES]);
+
+  useEffect(() => {
+    run();
+    return () => {
+      if (rafRef.current !== undefined) cancelAnimationFrame(rafRef.current);
+    };
+  }, [run]);
+
+  const bigSize = isMobile ? 56 : 104;
+  const lineSize = isMobile ? 28 : 44;
+
+  const renderLine = (segs: Segment[], count: number, style: CSSProperties, showCursor: boolean, cursorHeight: number) => {
+    const chars = segs.flatMap((s) => (isChip(s) ? [] : [...s.text].map((ch) => ({ ch, color: s.color }))));
+    const visible = chars.slice(0, count);
+    return (
+      <div style={style}>
+        {visible.map((c, i) => (<span key={i} style={{ color: c.color }}>{c.ch}</span>))}
+        <span style={{
+          display: 'inline-block',
+          width: 2,
+          height: cursorHeight,
+          background: theme.tint,
+          marginLeft: 3,
+          verticalAlign: '-0.12em',
+          opacity: showCursor ? 1 : 0,
+          animation: showCursor ? 'mmLandingBlink 1s steps(2) infinite' : 'none',
+        }} />
+      </div>
+    );
+  };
+
+  return (
+    <section style={{
+      minHeight: isMobile ? 'calc(100vh - 80px)' : '86vh',
+      display: 'flex', flexDirection: 'column', justifyContent: 'center',
+      padding: isMobile ? '12px 0 24px' : '40px 0 60px',
+      position: 'relative',
+    }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: isMobile ? 14 : 22, maxWidth: isMobile ? '100%' : 860 }}>
+        {renderLine(LINES[0], counts[0], {
+          fontFamily: FONT_STACK,
+          fontSize: bigSize, fontWeight: 700,
+          letterSpacing: '-0.035em', lineHeight: 1,
+          minHeight: bigSize,
+        }, activeLine === 0, bigSize * 0.82)}
+
+        {renderLine(LINES[1], counts[1], {
+          fontFamily: FONT_STACK,
+          fontSize: lineSize, fontWeight: 600,
+          letterSpacing: '-0.02em', lineHeight: 1.2,
+          minHeight: lineSize * 1.2,
+        }, activeLine === 1, lineSize * 0.95)}
+
+        {renderLine(LINES[2], counts[2], {
+          fontFamily: FONT_STACK,
+          fontSize: lineSize, fontWeight: 600,
+          letterSpacing: '-0.02em', lineHeight: 1.2,
+          minHeight: lineSize * 1.2,
+        }, activeLine === 2, lineSize * 0.95)}
+
+        <ChatMessages theme={theme} isMobile={isMobile} messages={messages} responseMode={responseMode} />
+
+        <FadeSlide show={showInput}>
+          <UserInput
+            theme={theme}
+            isMobile={isMobile}
+            onSubmit={onSubmit}
+            onMicClick={onMicClick}
+            disabled={inputDisabled}
+          />
+        </FadeSlide>
+      </div>
+    </section>
+  );
+}
+
+function ReturningHero({ theme, isMobile, onSubmit, onMicClick, inputDisabled }: {
+  theme: Theme; isMobile: boolean;
+  onSubmit: (msg: string) => void; onMicClick: () => void; inputDisabled: boolean;
+}) {
+  const lineSize = isMobile ? 30 : 48;
+
+  const LINES: Segment[][] = useMemo(() => [[
+    { chip: { ar: 'أهلاً', latin: 'Ahlan', meaning: 'hello, welcome' } },
+    { text: ', salma — have you been practising your ', color: theme.ink },
+    { chip: { ar: 'خضراوات', latin: 'khadrawaat', meaning: 'vegetables' } },
+    { text: '?', color: theme.ink },
+  ]], [theme.ink]);
+
+  const [counts, setCounts] = useState([0]);
+  const [activeLine, setActiveLine] = useState(-1);
+  const [showAfter, setShowAfter] = useState(false);
+  const rafRef = useRef<number | undefined>(undefined);
+
+  const run = useCallback(() => {
+    setCounts([0]);
+    setActiveLine(-1);
+    setShowAfter(false);
+    const startAt = performance.now() + 150;
+    const lineDur = LINES.map((l) => (totalChars(l) / CPS) * 1000);
+    const lineStart: number[] = [];
+    for (let i = 0; i < LINES.length; i++) {
+      lineStart[i] = i === 0 ? startAt : lineStart[i - 1] + lineDur[i - 1] + LINE_GAP;
+    }
+
+    const tick = (now: number) => {
+      const next = LINES.map((l, i) => {
+        const t = now - lineStart[i];
+        if (t <= 0) return 0;
+        return Math.min(totalChars(l), Math.floor((t / 1000) * CPS));
+      });
+      setCounts(next);
+
+      let active = -1;
+      for (let i = 0; i < LINES.length; i++) if (now >= lineStart[i]) active = i;
+      setActiveLine(active);
+
+      const lastEnd = lineStart[LINES.length - 1] + lineDur[LINES.length - 1];
+      if (now < lastEnd + 400) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        setActiveLine(-1);
+        setTimeout(() => setShowAfter(true), 200);
+      }
+    };
+    rafRef.current = requestAnimationFrame(tick);
+  }, [LINES]);
+
+  useEffect(() => {
+    run();
+    return () => {
+      if (rafRef.current !== undefined) cancelAnimationFrame(rafRef.current);
+    };
+  }, [run]);
+
+  const renderLine = (segs: Segment[], count: number, showCursor: boolean) => {
+    const atoms: Array<
+      | { type: 'ch'; ch: string; color: string; key: string }
+      | { type: 'chip'; data: { ar: string; latin: string; meaning: string }; key: string }
+    > = [];
+    segs.forEach((s, si) => {
+      if (isChip(s)) atoms.push({ type: 'chip', data: s.chip, key: `c${si}` });
+      else [...s.text].forEach((ch, ci) => atoms.push({ type: 'ch', ch, color: s.color, key: `t${si}-${ci}` }));
+    });
+    const visible = atoms.slice(0, count);
+    return (
+      <div style={{
+        fontFamily: FONT_STACK,
+        fontSize: lineSize, fontWeight: 600,
+        letterSpacing: '-0.02em', lineHeight: 1.2,
+        minHeight: lineSize * 1.2,
+      }}>
+        {visible.map((a) => a.type === 'ch'
+          ? (<span key={a.key} style={{ color: a.color }}>{a.ch}</span>)
+          : (<ArabicChip key={a.key} theme={theme} {...a.data} />))}
+        <span style={{
+          display: 'inline-block', width: 2, height: lineSize * 0.95,
+          background: theme.tint, marginLeft: 3, verticalAlign: '-0.12em',
+          opacity: showCursor ? 1 : 0,
+          animation: showCursor ? 'mmLandingBlink 1s steps(2) infinite' : 'none',
+        }} />
+      </div>
+    );
+  };
+
+  return (
+    <section style={{
+      minHeight: isMobile ? 'calc(100vh - 80px)' : '86vh',
+      display: 'flex', flexDirection: 'column', justifyContent: 'center',
+      padding: isMobile ? '12px 0 24px' : '40px 0 60px',
+      position: 'relative',
+    }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: isMobile ? 18 : 26, maxWidth: isMobile ? '100%' : 900 }}>
+        {renderLine(LINES[0], counts[0], activeLine === 0)}
+
+        <FadeSlide show={showAfter}>
+          <UserInput theme={theme} isMobile={isMobile}
+            prefilled="ayy, i tried to order fūl at breakfast…"
+            onSubmit={onSubmit}
+            onMicClick={onMicClick}
+            disabled={inputDisabled} />
+        </FadeSlide>
+
+        <FadeSlide show={showAfter} delay={200}>
+          <div style={{
+            display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap',
+            fontSize: 13, color: theme.sub, marginTop: isMobile ? 4 : 8,
+          }}>
+            <span>Or jump to</span>
+            {[
+              { l: 'Role-play: at the souk', ar: 'السوق' },
+              { l: 'Review 8 words', ar: null },
+              { l: 'Story · 2 min', ar: null },
+            ].map((x) => (
+              <button key={x.l} style={{
+                background: theme.surface, border: `1px solid ${theme.border}`,
+                borderRadius: 999, padding: '6px 12px', fontSize: 13, color: theme.ink,
+                cursor: 'pointer', fontFamily: 'inherit',
+                display: 'flex', alignItems: 'center', gap: 6,
+              }}>
+                {x.l}
+                {x.ar && <span style={{ fontFamily: 'Noto Sans Arabic, serif', direction: 'rtl', color: theme.tint }}>{x.ar}</span>}
+              </button>
+            ))}
+          </div>
+        </FadeSlide>
+      </div>
+    </section>
+  );
+}
+
+export function TopBar({ theme, isMobile, isReturning }: { theme: Theme; isMobile: boolean; isReturning: boolean }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      padding: isMobile ? '58px 20px 10px' : '28px 64px 14px',
+      position: 'sticky', top: 0, zIndex: 30,
+      background: `${theme.bg}e6`,
+      backdropFilter: 'blur(10px)',
+      WebkitBackdropFilter: 'blur(10px)',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+        <ApricotMark size={26} />
+        <span style={{
+          fontFamily: FONT_STACK, fontSize: 20, fontWeight: 700,
+          color: theme.ink, letterSpacing: '-0.02em',
+        }}>mishmish</span>
+      </div>
+      <button style={{
+        background: 'transparent', color: theme.sub, border: `1px solid ${theme.border}`,
+        borderRadius: 999, fontSize: 13, cursor: 'pointer',
+        padding: '7px 14px 7px 11px', fontFamily: 'inherit',
+        display: 'inline-flex', alignItems: 'center', gap: 7,
+      }}>
+        {isReturning ? <Icon.settings width={14} height={14} /> : <Icon.user width={14} height={14} />}
+        {isReturning ? 'Settings' : 'Sign in'}
+      </button>
+    </div>
+  );
+}
+
+export function QuietFooter({ theme, isMobile }: { theme: Theme; isMobile: boolean }) {
+  return (
+    <div style={{
+      marginTop: isMobile ? 32 : 60, paddingTop: 28,
+      borderTop: `1px solid ${theme.border}`,
+      display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      flexWrap: 'wrap', gap: 16,
+      color: theme.sub, fontSize: 12.5,
+    }}>
+      <div>© mishmish · an Arabic tutor that lets you ramble</div>
+      <div style={{ display: 'flex', gap: 18 }}>
+        {['Egyptian', 'MSA', 'Iraqi'].map((d) => (<span key={d}>{d}</span>))}
+      </div>
+    </div>
+  );
+}
+
+export type LandingProps = {
+  userState?: UserState;
+  color?: ThemeKey;
+};
+
+export function Landing({ userState = 'new', color = 'apricot' }: LandingProps) {
+  const theme = THEMES[color];
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth < 768 : false
+  );
+  const isReturning = userState === 'returning';
+
+  useEffect(() => {
+    const onResize = () => setIsMobile(window.innerWidth < 768);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  const loadSessions = useStore((s) => s.session.loadSessions);
+  const sendMessage = useStore((s) => s.session.sendMessage);
+  const activeSessionId = useStore((s) => s.session.activeSessionId);
+  const messages = useStore((s) => s.session.messages);
+  const setMessages = useStore((s) => s.session.setMessages);
+  const addMessage = useStore((s) => s.session.addMessage);
+  const responseMode = useStore((s) => s.session.context.response_mode);
+  const supabase = useSupabase();
+
+  useEffect(() => {
+    loadSessions();
+  }, [loadSessions]);
+
+  useTranscriptMessages();
+
+  const refetchMessages = useCallback(async () => {
+    if (!activeSessionId) return;
+    const { data, error } = await supabase
+      .from('transcript_messages')
+      .select('*')
+      .eq('session_id', activeSessionId)
+      .order('created_at', { ascending: true });
+    if (!error && data) setMessages(data as TranscriptMessage[]);
+  }, [supabase, activeSessionId, setMessages]);
+
+  const handleSubmit = useCallback(async (msg: string) => {
+    if (!activeSessionId) return;
+    // Optimistic add so the user sees their message immediately
+    const optimisticId = `optimistic-${Date.now()}`;
+    addMessage({
+      message_id: optimisticId,
+      session_id: activeSessionId,
+      user_id: '',
+      message_source: 'user',
+      message_kind: 'text',
+      message_text: msg,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    try {
+      await sendMessage(msg);
+    } catch (err) {
+      console.error('sendMessage failed', err);
+    }
+    // Refetch to reconcile optimistic message + pull in tutor reply (realtime can be flaky in dev)
+    await refetchMessages();
+  }, [activeSessionId, addMessage, sendMessage, refetchMessages]);
+
+  const handleMicClick = useCallback(() => {
+    window.location.href = '/';
+  }, []);
+
+  const gutter = isMobile ? 20 : 64;
+  const containerMax = isMobile ? '100%' : 1100;
+
+  return (
+    <div style={{
+      background: theme.bg, color: theme.ink, minHeight: '100vh',
+      fontFamily: FONT_STACK,
+      WebkitFontSmoothing: 'antialiased',
+      letterSpacing: '-0.01em',
+    }}>
+      <style>{`@keyframes mmLandingBlink { 0%, 50% { opacity: 1 } 50.01%, 100% { opacity: 0 } }`}</style>
+      <TopBar theme={theme} isMobile={isMobile} isReturning={isReturning} />
+      <div style={{
+        maxWidth: containerMax, margin: '0 auto',
+        padding: `0 ${gutter}px`, paddingBottom: 28,
+      }}>
+        {isReturning
+          ? <ReturningHero theme={theme} isMobile={isMobile}
+              onSubmit={handleSubmit} onMicClick={handleMicClick}
+              inputDisabled={!activeSessionId} />
+          : <NewUserHero theme={theme} isMobile={isMobile}
+              messages={messages} responseMode={responseMode}
+              onSubmit={handleSubmit} onMicClick={handleMicClick}
+              inputDisabled={!activeSessionId} />}
+        <QuietFooter theme={theme} isMobile={isMobile} />
+      </div>
+    </div>
+  );
+}
+
+export default Landing;

--- a/web-app/src/pages/Onboarding.stories.tsx
+++ b/web-app/src/pages/Onboarding.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Onboarding from './Onboarding';
+
+const meta = {
+  title: 'Pages/Onboarding',
+  component: Onboarding,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof Onboarding>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NameStep: Story = {
+  args: { color: 'apricot' },
+  parameters: { initialEntries: ['/onboarding/name'] },
+};
+
+export const MotivationStep: Story = {
+  args: { color: 'apricot' },
+  parameters: { initialEntries: ['/onboarding/motivation'] },
+  decorators: [
+    (Story) => {
+      sessionStorage.setItem('mishmish:onboarding:name', 'Salma');
+      return <Story />;
+    },
+  ],
+};
+
+export const SuggestionsStep: Story = {
+  args: { color: 'apricot' },
+  parameters: { initialEntries: ['/onboarding/suggestions'] },
+  decorators: [
+    (Story) => {
+      sessionStorage.setItem('mishmish:onboarding:name', 'Salma');
+      return <Story />;
+    },
+  ],
+};

--- a/web-app/src/pages/Onboarding.tsx
+++ b/web-app/src/pages/Onboarding.tsx
@@ -1,0 +1,386 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  FONT_STACK,
+  QuietFooter,
+  THEMES,
+  TopBar,
+  UserInput,
+  type ThemeKey,
+} from './Landing';
+
+export type OnboardingProps = {
+  color?: ThemeKey;
+};
+
+type Step = 'name' | 'motivation' | 'suggestions';
+
+type SuggestionTile = {
+  level: string;
+  title: string;
+  blurb: string;
+  arabic?: string;
+};
+
+const SUGGESTION_TILES: SuggestionTile[] = [
+  {
+    level: 'Beginner',
+    title: 'Your first 10 words',
+    blurb: 'Greetings, ordering coffee, saying your name — enough to feel brave.',
+    arabic: 'مرحبا',
+  },
+  {
+    level: 'Intermediate',
+    title: 'Café in Cairo',
+    blurb: 'Role-play ordering, small talk, asking for the bill — realistic and fun.',
+    arabic: 'قهوة',
+  },
+  {
+    level: 'Advanced',
+    title: 'Today\u2019s headlines',
+    blurb: 'Unpack a news story together — vocabulary for current affairs and opinion.',
+    arabic: 'أخبار',
+  },
+];
+
+type TextSegment = { text: string; color: string };
+type Line = TextSegment[];
+
+const CPS = 32;
+const LINE_GAP = 800;
+const FADE_MS = 350;
+const segCharCount = (l: Line) => l.reduce((n, s) => n + [...s.text].length, 0);
+
+function TypingHero({ lines, isMobile, theme, runKey }: {
+  lines: Line[]; isMobile: boolean; theme: { tint: string; ink: string };
+  runKey: string | number;
+}) {
+  const [counts, setCounts] = useState<number[]>(() => lines.map(() => 0));
+  const [activeLine, setActiveLine] = useState(-1);
+  const rafRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    setCounts(lines.map(() => 0));
+    setActiveLine(-1);
+
+    const startAt = performance.now() + 150;
+    const lineDur = lines.map((l) => (segCharCount(l) / CPS) * 1000);
+    const lineStart: number[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      lineStart[i] = i === 0 ? startAt : lineStart[i - 1] + lineDur[i - 1] + LINE_GAP;
+    }
+
+    const tick = (now: number) => {
+      const next = lines.map((l, i) => {
+        const t = now - lineStart[i];
+        if (t <= 0) return 0;
+        return Math.min(segCharCount(l), Math.floor((t / 1000) * CPS));
+      });
+      setCounts(next);
+
+      let active = -1;
+      for (let i = 0; i < lines.length; i++) if (now >= lineStart[i]) active = i;
+      setActiveLine(active);
+
+      const lastEnd = lineStart[lines.length - 1] + lineDur[lines.length - 1];
+      if (now < lastEnd + 400) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        setActiveLine(-1);
+      }
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current !== undefined) cancelAnimationFrame(rafRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runKey]);
+
+  const bigSize = isMobile ? 56 : 104;
+  const lineSize = isMobile ? 28 : 44;
+
+  const renderLine = (segs: Line, count: number, style: CSSProperties, showCursor: boolean, cursorHeight: number) => {
+    const chars = segs.flatMap((s) => [...s.text].map((ch) => ({ ch, color: s.color })));
+    const visible = chars.slice(0, count);
+    return (
+      <div style={style}>
+        {visible.map((c, i) => (<span key={i} style={{ color: c.color }}>{c.ch}</span>))}
+        <span style={{
+          display: 'inline-block', width: 2, height: cursorHeight,
+          background: theme.tint, marginLeft: 3, verticalAlign: '-0.12em',
+          opacity: showCursor ? 1 : 0,
+          animation: showCursor ? 'mmLandingBlink 1s steps(2) infinite' : 'none',
+        }} />
+      </div>
+    );
+  };
+
+  // First line gets "big" treatment only if it's the only huge headline (name step).
+  // For a multi-line layout, first line is big if lines.length >= 3 and first line is short;
+  // otherwise all lines use lineSize. Caller controls this via the passed lines.
+  const firstIsBig = lines.length >= 3 && segCharCount(lines[0]) <= 20;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: isMobile ? 14 : 22 }}>
+      {lines.map((l, i) => {
+        const isBig = firstIsBig && i === 0;
+        const size = isBig ? bigSize : lineSize;
+        const weight = isBig ? 700 : 600;
+        const letterSpacing = isBig ? '-0.035em' : '-0.02em';
+        const lineHeight = isBig ? 1 : 1.2;
+        return renderLine(l, counts[i] ?? 0, {
+          fontFamily: FONT_STACK,
+          fontSize: size, fontWeight: weight,
+          letterSpacing, lineHeight,
+          minHeight: isBig ? size : size * 1.2,
+        }, activeLine === i, isBig ? size * 0.82 : size * 0.95);
+      })}
+    </div>
+  );
+}
+
+export function Onboarding({ color = 'apricot' }: OnboardingProps) {
+  const theme = THEMES[color];
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth < 768 : false
+  );
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const onResize = () => setIsMobile(window.innerWidth < 768);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  // Resolve current step from path. /onboarding → treat as /name.
+  const step: Step = location.pathname.endsWith('/motivation')
+    ? 'motivation'
+    : location.pathname.endsWith('/suggestions')
+      ? 'suggestions'
+      : 'name';
+
+  // Redirect bare /onboarding to /onboarding/name
+  useEffect(() => {
+    if (location.pathname === '/onboarding' || location.pathname === '/onboarding/') {
+      navigate('/onboarding/name', { replace: true });
+    }
+  }, [location.pathname, navigate]);
+
+  // Name persists across steps. In future this will come from the LLM extracting
+  // the name from the user's free-text reply.
+  const [name, setName] = useState<string>(() => sessionStorage.getItem('mishmish:onboarding:name') || '');
+
+  // Fade-transition the hero lines when the step changes.
+  const [displayStep, setDisplayStep] = useState<Step>(step);
+  const [linesVisible, setLinesVisible] = useState(true);
+
+  useEffect(() => {
+    if (displayStep === step) return;
+    setLinesVisible(false);
+    const t = setTimeout(() => {
+      setDisplayStep(step);
+      setLinesVisible(true);
+    }, FADE_MS);
+    return () => clearTimeout(t);
+  }, [step, displayStep]);
+
+  // Suggestion tiles reveal after the typing animation finishes on the suggestions step.
+  const [tilesVisible, setTilesVisible] = useState(false);
+  useEffect(() => {
+    if (displayStep !== 'suggestions') {
+      setTilesVisible(false);
+      return;
+    }
+    const t = setTimeout(() => setTilesVisible(true), 2400);
+    return () => clearTimeout(t);
+  }, [displayStep]);
+
+  const lines: Line[] = useMemo(() => {
+    if (displayStep === 'motivation') {
+      const greetName = name || 'friend';
+      return [
+        [
+          { text: 'ahlan', color: theme.tint },
+          { text: ` ya ${greetName}!`, color: theme.ink },
+        ],
+        [
+          { text: 'tell me, why are you curious to learn ', color: theme.ink },
+          { text: 'arabii', color: theme.tint },
+          { text: '?', color: theme.ink },
+        ],
+      ];
+    }
+    if (displayStep === 'suggestions') {
+      return [
+        [
+          { text: 'mumtaz', color: theme.tint },
+          { text: "! that's a great reason to learn!", color: theme.ink },
+        ],
+        [{ text: 'where shall we begin?', color: theme.ink }],
+      ];
+    }
+    // name step (default)
+    return [
+      [{ text: 'marhaban!', color: theme.tint }],
+      [
+        { text: "i'm ", color: theme.ink },
+        { text: 'mishmish', color: theme.tint },
+        { text: ', which means apricot \uD83D\uDE0A', color: theme.ink },
+      ],
+      [{ text: 'what is your name?', color: theme.ink }],
+    ];
+  }, [displayStep, name, theme.tint, theme.ink]);
+
+  const handleSubmit = useCallback((msg: string) => {
+    const trimmed = msg.trim();
+    if (step === 'name') {
+      // Naive client-side extraction for now — real extraction will happen on the backend.
+      // Take the last "word" that looks like a name; fall back to the whole message.
+      const guessed = trimmed.split(/\s+/).pop() || trimmed;
+      setName(guessed);
+      sessionStorage.setItem('mishmish:onboarding:name', guessed);
+      navigate('/onboarding/motivation');
+    } else if (step === 'motivation') {
+      sessionStorage.setItem('mishmish:onboarding:motivation', trimmed);
+      navigate('/onboarding/suggestions');
+    } else {
+      // suggestions — free-text entry falls through to the main app.
+      sessionStorage.setItem('mishmish:onboarding:freeText', trimmed);
+      navigate('/');
+    }
+  }, [step, navigate]);
+
+  const handleSuggestionPick = useCallback((tile: SuggestionTile) => {
+    sessionStorage.setItem('mishmish:onboarding:pick', tile.level.toLowerCase());
+    navigate('/');
+  }, [navigate]);
+
+  const handleMicClick = useCallback(() => {
+    navigate('/');
+  }, [navigate]);
+
+  const gutter = isMobile ? 20 : 64;
+  const containerMax = isMobile ? '100%' : 1100;
+
+  return (
+    <div style={{
+      background: theme.bg, color: theme.ink, minHeight: '100vh',
+      fontFamily: FONT_STACK,
+      WebkitFontSmoothing: 'antialiased',
+      letterSpacing: '-0.01em',
+    }}>
+      <style>{`@keyframes mmLandingBlink { 0%, 50% { opacity: 1 } 50.01%, 100% { opacity: 0 } }`}</style>
+      <TopBar theme={theme} isMobile={isMobile} isReturning={false} />
+      <div style={{
+        maxWidth: containerMax, margin: '0 auto',
+        padding: `0 ${gutter}px`, paddingBottom: 28,
+      }}>
+        <section style={{
+          minHeight: isMobile ? 'calc(100vh - 80px)' : '86vh',
+          display: 'flex', flexDirection: 'column', justifyContent: 'center',
+          padding: isMobile ? '12px 0 24px' : '40px 0 60px',
+          position: 'relative',
+        }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: isMobile ? 14 : 22, maxWidth: isMobile ? '100%' : 860 }}>
+            {/* Hero lines — fade out/in on step change */}
+            <div
+              style={{
+                opacity: linesVisible ? 1 : 0,
+                transition: `opacity ${FADE_MS}ms cubic-bezier(.2,.7,.3,1)`,
+              }}
+            >
+              <TypingHero lines={lines} isMobile={isMobile} theme={theme} runKey={displayStep} />
+            </div>
+
+            {/* Suggestion tiles — only on the suggestions step, fade/slide in after the lines type */}
+            {displayStep === 'suggestions' && (
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: isMobile ? 'column' : 'row',
+                  gap: isMobile ? 12 : 16,
+                  opacity: tilesVisible ? 1 : 0,
+                  transform: tilesVisible ? 'translateY(0)' : 'translateY(12px)',
+                  transition: 'opacity 500ms cubic-bezier(.2,.7,.3,1), transform 500ms cubic-bezier(.2,.7,.3,1)',
+                  pointerEvents: tilesVisible ? 'auto' : 'none',
+                }}
+              >
+                {SUGGESTION_TILES.map((tile) => (
+                  <button
+                    key={tile.level}
+                    onClick={() => handleSuggestionPick(tile)}
+                    style={{
+                      flex: 1,
+                      textAlign: 'left',
+                      padding: isMobile ? '16px 18px' : '20px 22px',
+                      background: theme.surface,
+                      border: `1px solid ${theme.border}`,
+                      borderRadius: 18,
+                      cursor: 'pointer',
+                      fontFamily: 'inherit',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 10,
+                      transition: 'transform 200ms, box-shadow 200ms, border-color 200ms',
+                    }}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.borderColor = theme.tint;
+                      e.currentTarget.style.transform = 'translateY(-2px)';
+                      e.currentTarget.style.boxShadow = `0 16px 32px -20px ${theme.tint}88`;
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.borderColor = theme.border;
+                      e.currentTarget.style.transform = 'translateY(0)';
+                      e.currentTarget.style.boxShadow = 'none';
+                    }}
+                  >
+                    <div style={{
+                      display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10,
+                    }}>
+                      <span style={{
+                        fontSize: 11, fontWeight: 700, letterSpacing: '0.08em',
+                        textTransform: 'uppercase', color: theme.tintDeep,
+                        background: theme.tintSoft,
+                        padding: '3px 8px', borderRadius: 999,
+                      }}>{tile.level}</span>
+                      {tile.arabic && (
+                        <span style={{
+                          fontFamily: 'Noto Sans Arabic, serif', direction: 'rtl',
+                          fontSize: 18, color: theme.tint,
+                        }}>{tile.arabic}</span>
+                      )}
+                    </div>
+                    <div style={{
+                      fontSize: isMobile ? 17 : 19,
+                      fontWeight: 700,
+                      color: theme.ink,
+                      letterSpacing: '-0.01em',
+                      lineHeight: 1.2,
+                    }}>{tile.title}</div>
+                    <div style={{
+                      fontSize: 13.5,
+                      color: theme.sub,
+                      lineHeight: 1.45,
+                    }}>{tile.blurb}</div>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {/* User input persists across steps (no key change → no remount) */}
+            <UserInput
+              theme={theme}
+              isMobile={isMobile}
+              onSubmit={handleSubmit}
+              onMicClick={handleMicClick}
+            />
+          </div>
+        </section>
+        <QuietFooter theme={theme} isMobile={isMobile} />
+      </div>
+    </div>
+  );
+}
+
+export default Onboarding;


### PR DESCRIPTION
## Summary
- New `/landing` page (pixel port of the Mishmish Landing design) wired to the existing chat pipeline — text input swaps between mic and send button based on content, and messages render as bubbles respecting the user's `response_mode` setting.
- New multi-step onboarding flow at `/onboarding` (`/name` → `/motivation` → `/suggestions`) with a fade transition between steps that keeps the text input anchored and re-animates the hero lines. Name persists across steps via `sessionStorage`. Suggestions step shows 3 level-tagged tiles (beginner / intermediate / advanced).
- Storybook stories for Landing (ReturningUser) and each onboarding step, using a MemoryRouter decorator that reads `parameters.initialEntries`.
- Admin-app: new "Flows → Onboarding → Name / Motivation / Suggestions" sidebar. Each step has separate editors for `prompt`, `schema`, and `examples`. Examples render as individually editable textareas with `+ Add Example` and a trash-icon delete guarded by an alert dialog.
- Web-api: generalised `GET/PUT /admin/prompts/flows/{flow}/{step}/{section}` endpoints with section allowlist + path-traversal guard, so new flows/steps only need markdown files dropped in.
- Seed prompt/schema/examples markdown for the three onboarding steps.

## Test plan
- [ ] `npm run dev` in web-app → visit `/onboarding`, confirm redirect to `/onboarding/name` and typing a name advances through motivation and suggestions.
- [ ] Confirm fade + re-type animation between steps; text input stays put.
- [ ] On `/landing`, type into the input and confirm the mic icon swaps to a send icon; submit and confirm the message bubble appears and the agent replies.
- [ ] `npm run storybook` → ReturningUser, NameStep, MotivationStep, SuggestionsStep all render without errors.
- [ ] Admin-app: navigate Flows → Onboarding → Name; edit prompt / schema / add + delete examples; confirm PUT persists to the markdown files and delete triggers the confirmation dialog.
- [ ] `uv run pytest` in web-api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)