### PR TITLE
chore(supabase): seed free + pro test users for local and preview

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -64,6 +64,11 @@ supabase migration up # Apply pending migrations locally (preferred)
 - All schema changes must be done via migration files in `supabase/migrations/`.
 - Before any database refactor, check whether `[experimental.pgdelta]` in `supabase/config.toml` is ready for use. As of March 2026 it was alpha (CLI v2.83.0, `@supabase/pg-delta@1.0.0-alpha.4`). If stable, it can replace the manual `supabase db diff` workflow with a proper declarative sync engine. See: supabase.com/docs/guides/local-development/declarative-database-schemas and github.com/supabase/pg-toolbelt.
 
+**Seeded test users (local + preview environments only):**
+- `freeloader@mishmish.io` / `password` — free plan user, for testing free-tier limits and quota enforcement.
+- `pro@mishmish.io` / `password` — pro plan user, for testing paid features.
+- `test@mishmish.io` / `password` — scratch user for exercising the signup/onboarding flow. Not seeded; create it via the signup UI whenever you need a fresh new-user flow. It is always safe to delete `test@mishmish.io` and all their associated data (profile, conversations, messages, usage events, etc.) from the database to re-run signup from scratch.
+
 ## Architecture
 
 ### Voice Pipeline (web-api)

--- a/supabase/seed/users.sql
+++ b/supabase/seed/users.sql
@@ -43,3 +43,53 @@ WHERE NOT EXISTS (
 UPDATE public.profiles
 SET is_admin = true
 WHERE id = (SELECT id FROM auth.users WHERE email = 'tanyagray.nz@gmail.com');
+
+-- Seed test users for local and preview deployments
+-- freeloader@mishmish.io — free plan, password: password
+-- pro@mishmish.io — pro plan, password: password
+INSERT INTO auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  created_at,
+  updated_at,
+  confirmation_token,
+  recovery_token,
+  email_change,
+  email_change_token_new,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  is_super_admin
+)
+SELECT
+  '00000000-0000-0000-0000-000000000000',
+  gen_random_uuid(),
+  'authenticated',
+  'authenticated',
+  email,
+  crypt('password', gen_salt('bf')),
+  now(),
+  now(),
+  now(),
+  '',
+  '',
+  '',
+  '',
+  '{"provider": "email", "providers": ["email"]}',
+  '{}',
+  false
+FROM (VALUES ('freeloader@mishmish.io'), ('pro@mishmish.io')) AS v(email)
+WHERE NOT EXISTS (
+  SELECT 1 FROM auth.users u WHERE u.email = v.email
+);
+
+-- Upgrade pro@mishmish.io to the pro plan (freeloader keeps the default 'free')
+UPDATE public.profiles
+SET plan = 'pro',
+    subscription_status = 'active',
+    current_period_end = now() + interval '30 days'
+WHERE id = (SELECT id FROM auth.users WHERE email = 'pro@mishmish.io');


### PR DESCRIPTION
## Summary
- Seed `freeloader@mishmish.io` (free plan) and `pro@mishmish.io` (pro plan) into `supabase/seed/users.sql` so local and preview environments have ready-made accounts for testing plan-gated features and quota enforcement. Both use the password `password`.
- The pro seed user is upgraded to `plan='pro'` with `subscription_status='active'` and a 30-day `current_period_end`.
- Document the seeded users in `CLAUDE.md`, plus a convention that `test@mishmish.io` / `password` is a scratch account for exercising the signup/onboarding flow and is always safe to delete (along with all associated data) to restart that flow from scratch.

## Test plan
- [ ] `supabase db reset` locally and confirm both seeded users exist in `auth.users`.
- [ ] Log in as `freeloader@mishmish.io` / `password` and verify free-tier limits apply.
- [ ] Log in as `pro@mishmish.io` / `password` and verify pro features are unlocked.
- [ ] Confirm the same users appear in a preview environment after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)