### PR TITLE
feat(web-app): replace dotted underline on onboarding highlights with background pill

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -10,6 +10,8 @@ Arabic Voice Agent — a monorepo with a FastAPI voice/chat backend (web-api), R
 
 When asked to "start the app", run the **"Start All Services"** VS Code task (`Cmd+Shift+B`). This starts Supabase, web-api, and web-app in separate terminals.
 
+**Before making changes to the web-app**, ensure all services are running (Supabase + web-api + web-app), not just the Vite dev server. The web-app fetches its runtime config and onboarding/landing content from web-api (which in turn depends on Supabase), so without the full stack the app renders a "Failed to load app configuration" error and you cannot visually verify UI changes. If services aren't already up, run the "Start All Services" task before previewing.
+
 ## Common Commands
 
 ### web-api (Python, uv)

--- a/web-app/src/pages/Onboarding.tsx
+++ b/web-app/src/pages/Onboarding.tsx
@@ -46,7 +46,11 @@ function HighlightSpan({
       style={{
         color: seg.color,
         cursor: 'pointer',
-        borderBottom: `1px dashed ${seg.color}66`,
+        backgroundColor: `${seg.color}22`,
+        borderRadius: '4px',
+        padding: '2px 6px',
+        display: 'inline-block',
+        lineHeight: 1,
       }}
       onClick={(e) => {
         e.stopPropagation();


### PR DESCRIPTION
## Summary
- Replace the `1px dashed` borderBottom on highlighted Arabizi words in the onboarding hero with a soft tinted background pill (display: inline-block + line-height: 1) so the highlight hugs the text instead of stretching to the full line box.
- Add CLAUDE.md guidance to start the full stack (Supabase + web-api + web-app) before working on web-app changes — without the API the app errors out and UI changes can't be visually verified.

## Test plan
- [x] Verified visually in preview: "marhaban" and "Mishmish" render as tight rounded pills, no vertical overflow into adjacent lines.
- [ ] Reviewer: confirm hover popover still appears on highlighted words on desktop.
- [ ] Reviewer: confirm tap behavior still works on touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)