### PR TITLE
chore: add open-in-vscode skill and allow claude scope

### DIFF
--- a/.claude/skills/open-in-vscode.md
+++ b/.claude/skills/open-in-vscode.md
@@ -1,0 +1,53 @@
+---
+name: open-in-vscode
+description: >
+  Opens the current project/worktree in VS Code and jumps to the most relevant
+  file given the conversation context. Trigger when the user says things like
+  "show me the code", "open in ide", "open in vscode", "let me review the code",
+  "take me to the code", "open this in my editor", or "/open-in-vscode".
+user-invocable: true
+allowed-tools: Bash, Read
+argument-hint: "[optional file hint]"
+---
+
+# Open in VS Code
+
+Launch VS Code on the current worktree and navigate to the file most likely
+relevant to what the user just asked about.
+
+## Steps
+
+1. **Determine the project root.** Run `git rev-parse --show-toplevel`. If not
+   in a git repo, fall back to the current working directory. This will be the
+   current worktree path when invoked from one.
+
+2. **Pick the most relevant file** from conversation context, in priority
+   order:
+   - A file the user explicitly named in this turn or a recent turn.
+   - A file you just edited or created this session.
+   - A file central to the topic just discussed (one quick Grep is fine — do
+     not over-search).
+   - If nothing stands out, open the project root with no `--goto`.
+
+   If a specific line is relevant (e.g. a function just discussed), append
+   `:LINE` or `:LINE:COL`.
+
+   If the user passed an argument to the skill, treat it as the path hint and
+   skip the heuristics.
+
+3. **Open VS Code.** Run a single command:
+   ```bash
+   code <project_root> [--goto <file>[:line[:col]]]
+   ```
+   If `code` is not on PATH, fall back to
+   `open -a "Visual Studio Code" <project_root>` and note that the line jump
+   was skipped.
+
+4. **Confirm briefly** — one sentence naming the file (as a markdown link)
+   and why you picked it. Do not summarize the conversation.
+
+## Notes
+
+- Open exactly one file. Pick the single best candidate.
+- Do not run builds, tests, or any other tooling.
+- Do not block on the `code` command — it returns immediately.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -37,6 +37,7 @@ jobs:
             supabase
             config
             main
+            claude
           requireScope: false
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: >

--- a/claude.md
+++ b/claude.md
@@ -120,7 +120,7 @@ Format: `<type>[optional scope]: <description>`
 
 Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
 
-Scopes typically match the package: `web-api`, `web-app`, `flutter-app`, `admin-app`, `storybook`, `supabase`, `config`.
+Scopes typically match the package: `web-api`, `web-app`, `flutter-app`, `admin-app`, `storybook`, `supabase`, `config`, `claude`.
 
 Breaking changes: add `!` after type/scope (e.g., `feat!: change API structure`).
 


### PR DESCRIPTION
## Summary
- Adds a new user-invocable Claude skill at `.claude/skills/open-in-vscode.md` that opens the current worktree in VS Code and jumps to the most contextually relevant file. Triggers on phrases like "show me the code", "open in ide", "let me review the code", or `/open-in-vscode`.
- Falls back to `open -a "Visual Studio Code"` when `code` isn't on PATH.
- Adds `claude` as a valid conventional-commit scope (PR-title check + CLAUDE.md) so changes under `.claude/` can be scoped meaningfully.

## Test plan
- [ ] Reload Claude Code so the skill registers
- [ ] Say "show me the code" mid-conversation and confirm VS Code opens to a relevant file
- [ ] Try `/open-in-vscode path/to/file.ts:42` and confirm it jumps to that line
- [ ] Confirm the PR-title check passes with the `chore(claude): ...` scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)