### PR TITLE
chore(claude): clean up preview services on worktree removal

### DIFF
--- a/.claude/hooks/supabase-owner.sh
+++ b/.claude/hooks/supabase-owner.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# PostToolUse hook for Bash — tracks which worktree/checkout "owns" the local
+# Supabase stack so that worktree cleanup doesn't tear it down out from under
+# someone else.
+#
+# Supabase Local has one shared Docker stack per project_id (see
+# supabase/config.toml). Every worktree's `supabase start` attaches to the same
+# containers, and `supabase stop` from anywhere kills them. We work around that
+# by writing a marker file at the main repo root containing the absolute path
+# of whoever last started the stack:
+#
+#   <main-repo-root>/.supabase-owner
+#
+# `supabase start` (or `supabase db reset`, which restarts) → claim.
+# `supabase stop`                                          → release.
+#
+# Works the same way from the main checkout (where it doubles as branch-level
+# ownership — switching branches keeps the marker because it's keyed by the
+# checkout's working tree, not the branch).
+
+set -uo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null || echo "")
+CWD=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || echo "")
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+case "$COMMAND" in
+  *"supabase start"*|*"supabase db reset"*) ACTION="claim" ;;
+  *"supabase stop"*)                        ACTION="release" ;;
+  *)                                        exit 0 ;;
+esac
+
+if [ -z "$CWD" ]; then
+  CWD="$PWD"
+fi
+
+# Locate the main repo root. `--git-common-dir` returns the shared .git dir
+# (same for all worktrees of a repo), and its parent is the main checkout.
+COMMON_DIR=$(cd "$CWD" 2>/dev/null && git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+if [ -z "$COMMON_DIR" ] || [ ! -d "$COMMON_DIR" ]; then
+  exit 0
+fi
+MAIN_ROOT=$(dirname "$COMMON_DIR")
+MARKER="$MAIN_ROOT/.supabase-owner"
+
+# The owner is the worktree/checkout root the command was issued from.
+OWNER_ROOT=$(cd "$CWD" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
+
+if [ "$ACTION" = "claim" ]; then
+  echo "$OWNER_ROOT" > "$MARKER"
+  echo "[supabase-owner] claimed by $OWNER_ROOT" >&2
+else
+  rm -f "$MARKER"
+  echo "[supabase-owner] released" >&2
+fi
+
+exit 0

--- a/.claude/hooks/worktree-cleanup.sh
+++ b/.claude/hooks/worktree-cleanup.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# PreToolUse hook for ExitWorktree — shuts down preview services tied to the
+# worktree before it is removed. Only runs when action is "remove".
+#
+# Stops:
+#   - Local Supabase stack (`supabase stop` in the worktree dir)
+#   - Any dev-server processes whose cwd is inside the worktree (uvicorn, vite,
+#     storybook, node, npm, debugpy, etc.)
+
+set -uo pipefail
+
+INPUT=$(cat)
+
+ACTION=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_input',{}).get('action',''))" 2>/dev/null || echo "")
+WORKTREE_PATH=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || echo "")
+
+if [ -z "$WORKTREE_PATH" ]; then
+  WORKTREE_PATH="$PWD"
+fi
+
+# Canonicalize so it matches what supabase-owner.sh wrote (`git rev-parse
+# --show-toplevel` returns a real path).
+CANONICAL=$(cd "$WORKTREE_PATH" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null || true)
+if [ -n "$CANONICAL" ]; then
+  WORKTREE_PATH="$CANONICAL"
+fi
+
+# Only clean up on "remove" — "keep" leaves the worktree intact, so leave its
+# services running too.
+if [ "$ACTION" != "remove" ]; then
+  exit 0
+fi
+
+# Only act on actual worktree directories.
+case "$WORKTREE_PATH" in
+  */.claude/worktrees/*) ;;
+  *)
+    echo "[worktree-cleanup] cwd $WORKTREE_PATH is not a worktree, skipping" >&2
+    exit 0
+    ;;
+esac
+
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+echo "[worktree-cleanup] Shutting down services for $WORKTREE_PATH..." >&2
+
+# 1. Stop Supabase — but ONLY if this worktree owns it.
+#
+# The Supabase Local stack is shared across every worktree and the main
+# checkout (one Docker project per project_id), so a blind `supabase stop`
+# would kill someone else's running stack. The supabase-owner.sh hook writes
+# a marker at <main-repo-root>/.supabase-owner containing the absolute path
+# of whoever ran `supabase start`. We only stop if that path matches us.
+if [ -f "$WORKTREE_PATH/supabase/config.toml" ] && command -v supabase >/dev/null 2>&1; then
+  COMMON_DIR=$(cd "$WORKTREE_PATH" 2>/dev/null && git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+  MAIN_ROOT=$(dirname "${COMMON_DIR:-/}")
+  MARKER="$MAIN_ROOT/.supabase-owner"
+
+  if [ ! -f "$MARKER" ]; then
+    echo "[worktree-cleanup]   no Supabase owner marker — leaving stack alone" >&2
+  else
+    OWNER=$(tr -d '[:space:]' < "$MARKER")
+    if [ "$OWNER" != "$WORKTREE_PATH" ]; then
+      echo "[worktree-cleanup]   Supabase owned by $OWNER — leaving stack alone" >&2
+    else
+      echo "[worktree-cleanup]   supabase stop (this worktree owns it)..." >&2
+      (cd "$WORKTREE_PATH" && supabase stop --no-backup) >&2 2>&1 \
+        && echo "[worktree-cleanup]   supabase stopped" >&2 \
+        || echo "[worktree-cleanup]   warning: supabase stop failed" >&2
+      rm -f "$MARKER"
+    fi
+  fi
+fi
+
+# 2. Kill any processes whose working directory is inside the worktree. This
+# catches uvicorn/vite/storybook/node/etc. started by preview tools or VS Code
+# tasks. Use lsof to find PIDs whose cwd is under the worktree path.
+if command -v lsof >/dev/null 2>&1; then
+  PIDS=$(lsof -d cwd -F pn 2>/dev/null \
+    | awk -v wt="$WORKTREE_PATH" '
+        /^p/ { pid=substr($0,2); next }
+        /^n/ {
+          path=substr($0,2)
+          if (index(path, wt) == 1) print pid
+        }' \
+    | sort -u)
+
+  if [ -n "$PIDS" ]; then
+    echo "[worktree-cleanup]   killing dev-server PIDs: $(echo $PIDS | tr '\n' ' ')" >&2
+    # SIGTERM first, give them a moment, then SIGKILL stragglers.
+    echo "$PIDS" | xargs -n1 kill -TERM 2>/dev/null || true
+    sleep 2
+    REMAINING=$(echo "$PIDS" | xargs -n1 -I{} sh -c 'kill -0 {} 2>/dev/null && echo {}' || true)
+    if [ -n "$REMAINING" ]; then
+      echo "$REMAINING" | xargs -n1 kill -KILL 2>/dev/null || true
+    fi
+  else
+    echo "[worktree-cleanup]   no dev-server processes found" >&2
+  fi
+fi
+
+echo "[worktree-cleanup] Done." >&2
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,26 @@
             "async": true
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/supabase-owner.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "ExitWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/worktree-cleanup.sh"
+          }
+        ]
       }
     ]
   }

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ node_modules/
 # dotenvx: encrypted env files (supabase) are safe to commit; keys file is not.
 supabase/.env.keys
 
+# Local marker tracking which worktree/checkout owns the shared Supabase stack.
+# Written by .claude/hooks/supabase-owner.sh on `supabase start`/`stop` so that
+# worktree cleanup only tears down Supabase when this checkout actually owns it.
+.supabase-owner
+
 # IDEs and editors
 .idea/
 *.swp

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "run supabase",
       "type": "shell",
-      "command": "supabase start",
+      "command": "supabase start && echo \"${workspaceFolder}\" > \"$(dirname \"$(git -C \"${workspaceFolder}\" rev-parse --path-format=absolute --git-common-dir)\")/.supabase-owner\"",
       "options": {
         "cwd": "${workspaceFolder}/supabase"
       },


### PR DESCRIPTION
## Summary

When a worktree is removed via `ExitWorktree`, its preview services kept
running — Supabase, uvicorn, vite, etc. This adds a cleanup hook that
shuts them down, with safe coordination so one worktree's cleanup doesn't
tear down a Supabase stack another worktree (or the main checkout) is
still using.

## What changed

- **New `PreToolUse` hook on `ExitWorktree`** — [.claude/hooks/worktree-cleanup.sh](.claude/hooks/worktree-cleanup.sh). Only runs when `action: \"remove\"`. Refuses to act outside `.claude/worktrees/`. Kills processes whose cwd is inside the worktree (SIGTERM → 2s → SIGKILL). Conditionally runs `supabase stop`.
- **New `PostToolUse` hook on `Bash`** — [.claude/hooks/supabase-owner.sh](.claude/hooks/supabase-owner.sh). Watches for `supabase start` / `supabase db reset` / `supabase stop` and writes/removes a `.supabase-owner` marker at the **main repo root** (located via `git rev-parse --git-common-dir`), so all worktrees and the main checkout share one source of truth.
- **VS Code `run supabase` task** ([.vscode/tasks.json](.vscode/tasks.json)) now writes the marker after `supabase start`, so `Cmd+Shift+B` claims ownership too.
- **`.gitignore`** — adds `.supabase-owner`.
- **`.claude/settings.json`** — registers the two new hooks.

## Why the marker

Supabase Local runs one shared Docker stack per `project_id` (see [supabase/config.toml](supabase/config.toml)). Every worktree's `supabase start` attaches to the same containers; `supabase stop` from anywhere kills them. Without ownership tracking, cleanup of worktree A would happily tear down the Supabase stack worktree B is actively using. The marker records who started the stack so cleanup only stops it when the requesting worktree is the owner. No marker → conservative skip.

## Branch behavior (bonus)

The marker is keyed by the checkout's working tree (canonical path from `git rev-parse --show-toplevel`), not the branch. So switching branches in the main checkout keeps ownership intact, which is the desired behavior.

## Test plan

- [ ] Spawn a worktree, run `supabase start` inside it via Claude → `.supabase-owner` at main repo root contains the worktree path.
- [ ] `ExitWorktree` with `action: \"remove\"` on that worktree → Supabase is stopped, marker is removed, dev servers are killed.
- [ ] Spawn worktree A, start Supabase. Spawn worktree B (no Supabase command). Remove B → Supabase keeps running, log shows \"owned by …A — leaving stack alone\".
- [ ] Start Supabase via VS Code `Run All Services` task → marker appears.
- [ ] `ExitWorktree` with `action: \"keep\"` → no cleanup runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)