### PR TITLE
feat(web-app): hold input and hero during agent reply, fade only on new message

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,9 +4,10 @@
     {
       "name": "web-app",
       "runtimeExecutable": "bash",
-      "runtimeArgs": ["-c", ". ~/.nvm/nvm.sh 2>/dev/null; npm run dev"],
+      "runtimeArgs": ["-c", ". ~/.nvm/nvm.sh 2>/dev/null; npm run dev -- --port $PORT"],
       "cwd": "web-app",
-      "port": 5173
+      "port": 5173,
+      "autoPort": true
     },
     {
       "name": "storybook",

--- a/web-app/src/pages/Landing.tsx
+++ b/web-app/src/pages/Landing.tsx
@@ -66,6 +66,13 @@ const Icon = {
       <path d="M21 3 14.5 21l-3.5-8-8-3.5L21 3z" />
     </svg>
   ),
+  spinner: (p: SVGProps<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" {...p}>
+      <circle cx="12" cy="12" r="9" strokeDasharray="40 60" opacity="0.95">
+        <animateTransform attributeName="transform" type="rotate" from="0 12 12" to="360 12 12" dur="0.8s" repeatCount="indefinite" />
+      </circle>
+    </svg>
+  ),
   user: (p: SVGProps<SVGSVGElement>) => (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" {...p}>
       <circle cx="12" cy="8" r="4" />
@@ -126,6 +133,7 @@ export function UserInput({ theme, isMobile, prefilled = null, autoFocus = true,
 }) {
   const [value, setValue] = useState(prefilled || '');
   const inputRef = useRef<HTMLInputElement>(null);
+  const wasDisabledRef = useRef(disabled);
 
   useEffect(() => {
     if (autoFocus) {
@@ -134,13 +142,22 @@ export function UserInput({ theme, isMobile, prefilled = null, autoFocus = true,
     }
   }, [autoFocus]);
 
+  // Clear the just-submitted text once the parent re-enables the input
+  // (i.e. the agent's reply has arrived). The submitted value remains visible
+  // while disabled so the user keeps context on what they sent.
+  useEffect(() => {
+    if (wasDisabledRef.current && !disabled) {
+      setValue('');
+      if (autoFocus) inputRef.current?.focus();
+    }
+    wasDisabledRef.current = disabled;
+  }, [disabled, autoFocus]);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const msg = value.trim();
     if (!msg || disabled) return;
     onSubmit(msg);
-    setValue('');
-    inputRef.current?.focus();
   };
 
   const handleMicClick = () => {
@@ -163,6 +180,7 @@ export function UserInput({ theme, isMobile, prefilled = null, autoFocus = true,
         type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}
+        disabled={disabled}
         autoComplete="off"
         style={{
           flex: 1, minWidth: 0,
@@ -174,7 +192,22 @@ export function UserInput({ theme, isMobile, prefilled = null, autoFocus = true,
           caretColor: theme.tint,
         }}
       />
-      {value.trim() ? (
+      {disabled ? (
+        <button
+          type="button"
+          disabled
+          aria-label="Sending message"
+          style={{
+            width: isMobile ? 44 : 54, height: isMobile ? 44 : 54, borderRadius: '50%',
+            background: theme.tint, color: '#fff', border: 'none', cursor: 'default',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+            boxShadow: `0 8px 24px -6px ${theme.tint}88`,
+            opacity: 0.85,
+          }}
+        >
+          <Icon.spinner width={isMobile ? 22 : 26} height={isMobile ? 22 : 26} />
+        </button>
+      ) : value.trim() ? (
         <button
           type="submit"
           aria-label="Send message"

--- a/web-app/src/pages/Onboarding.tsx
+++ b/web-app/src/pages/Onboarding.tsx
@@ -25,7 +25,7 @@ type TextSegment = { text: string; color: string; meaning?: string };
 type Line = TextSegment[];
 
 const CPS = 48;
-const FADE_MS = 350;
+const FADE_MS = 200;
 const segCharCount = (l: Line) => l.reduce((n, s) => n + [...s.text].length, 0);
 
 type PopoverState = { meaning: string; top: number; left: number };
@@ -353,26 +353,41 @@ export function Onboarding({ color = 'apricot' }: OnboardingProps) {
   // Cross-fade between turns so the swap reads softly.
   const [displayMessages, setDisplayMessages] = useState<TranscriptMessage[]>([]);
   const [displayTurn, setDisplayTurn] = useState<string>('');
+  // Mirrors `turnKey` but only advances in lockstep with `displayMessages`, so
+  // TypingHero doesn't see a new resetKey while it's still rendering the
+  // outgoing turn's lines (which would re-animate them mid-fade).
+  const [displayTurnKey, setDisplayTurnKey] = useState<string>('start');
   const [linesVisible, setLinesVisible] = useState(true);
 
   useEffect(() => {
     if (turnFingerprint === displayTurn) return;
-    // If this is the first batch of bubbles for a new turn (display was empty)
-    // we don't fade — just type them in. Subsequent bubbles within the same
-    // turn append without a fade either.
     const wasEmpty = displayMessages.length === 0;
-    if (wasEmpty || visibleTutorMessages.length >= displayMessages.length) {
+    const isFreshTurn = turnKey !== displayTurnKey;
+
+    // First bubbles ever, or appending more bubbles within the SAME turn —
+    // type in directly without a fade.
+    if (wasEmpty || (!isFreshTurn && visibleTutorMessages.length >= displayMessages.length)) {
       setDisplayMessages(visibleTutorMessages);
       setDisplayTurn(turnFingerprint);
+      setDisplayTurnKey(turnKey);
       setLinesVisible(true);
       return;
     }
-    // The visible set shrank (a new user submit cleared the previous turn's
-    // bubbles). Fade out, swap, fade in.
+
+    // Fresh turn (user just submitted) but the agent hasn't replied yet —
+    // keep the previous turn's bubbles visible so the user has context while
+    // they wait. Don't update display state.
+    if (isFreshTurn && visibleTutorMessages.length === 0) {
+      return;
+    }
+
+    // Fresh turn AND the first new tutor bubble has arrived — fade out the
+    // old bubbles, then swap to the new content (which TypingHero animates in).
     setLinesVisible(false);
     const t = setTimeout(() => {
       setDisplayMessages(visibleTutorMessages);
       setDisplayTurn(turnFingerprint);
+      setDisplayTurnKey(turnKey);
       setLinesVisible(true);
     }, FADE_MS);
     return () => clearTimeout(t);
@@ -398,7 +413,17 @@ export function Onboarding({ color = 'apricot' }: OnboardingProps) {
     [textMessages, theme.tint, theme.ink],
   );
 
+  // Tracks "user has submitted, waiting for agent reply". Drives the input's
+  // disabled/spinner state. We can't use `isAgentThinking` directly because it
+  // is also true on initial page load (before the first greeting), and we
+  // don't want the input to start out disabled.
+  const [submitPending, setSubmitPending] = useState(false);
+  useEffect(() => {
+    if (submitPending && !isAgentThinking) setSubmitPending(false);
+  }, [isAgentThinking, submitPending]);
+
   const handleSubmit = useCallback((msg: string) => {
+    setSubmitPending(true);
     sendMessage(msg);
   }, [sendMessage]);
 
@@ -455,7 +480,7 @@ export function Onboarding({ color = 'apricot' }: OnboardingProps) {
                 lines={lines}
                 isMobile={isMobile}
                 theme={theme}
-                resetKey={turnKey}
+                resetKey={displayTurnKey}
               />
             </div>
 
@@ -495,6 +520,7 @@ export function Onboarding({ color = 'apricot' }: OnboardingProps) {
               isMobile={isMobile}
               onSubmit={handleSubmit}
               onMicClick={handleMicClick}
+              disabled={submitPending}
             />
           </div>
         </section>


### PR DESCRIPTION
## Summary

- During the wait for the agent's reply, keep the user's submitted text in the input (disabled), swap the send button for a spinner, and keep the previous turn's hero text visible. Only once the new tutor message arrives does the old hero quickly (200ms) fade out so the new message can type in.
- Fixes a leftover bug where the hero's `resetKey` advanced ahead of its lines, causing `TypingHero` to re-animate the outgoing text mid-fade. A `displayTurnKey` mirror keeps `lines` and `resetKey` in lockstep so the outgoing turn stays still as it fades.
- Wires `submitPending` from `Onboarding` into `UserInput` to drive the disabled/spinner state without coupling to `isAgentThinking` (which is also true on initial page load before the greeting arrives).

Bonus: enables `autoPort` on the web-app preview launch config so a second worktree's preview can run when 5173 is occupied by a sibling.

## Test plan

- [x] Onboarding loads, initial greeting types in normally.
- [x] Submitting a message: input keeps the typed text, button becomes a spinning SVG button (`aria-label="Sending message"`), input is `disabled`.
- [x] Old hero text stays at full opacity during the wait — verified via DOM frame capture (`fadeTextLen` held at 98 chars, opacity stayed at 1) until the new tutor arrived.
- [x] On new tutor: old hero opacity transitions 1 → 0 over ~200ms, content swaps, new message types in character-by-character (`6, 12, 18, 24, …`) — no re-animation of the outgoing text.
- [x] After the swap: input clears and refocuses, button reverts to send/mic depending on input contents.
- [x] Append within the same turn (a second tutor bubble before the user submits again) still appends without a fade.
- [x] No console errors during the full flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)