### PR TITLE
feat(web-app): render onboarding greeting statically, skip LLM until first user submit

### DIFF
--- a/web-api/agent/onboarding/onboarding_agent.py
+++ b/web-api/agent/onboarding/onboarding_agent.py
@@ -32,9 +32,5 @@ harness_options = HarnessOptions(
     flow_tag="onboarding",
     user_message_kind="transcript",
     idle_followups=False,
-    user_none_system_prompt=(
-        "Begin onboarding now. Greet the learner warmly and ask their name. "
-        "Use the `say` tool to produce each chat bubble."
-    ),
-    fire_opener=True,
+    fire_opener=False,
 )

--- a/web-api/agent/onboarding/system.md
+++ b/web-api/agent/onboarding/system.md
@@ -27,7 +27,7 @@ Write in **English**. A single Arabic interjection (marhaban, ahlan, mumtaz, mas
 - Keep tone warm, concrete, low-pressure. No marketing voice.
 
 ## Opening turn
-On the very first turn (no learner message yet) greet the learner warmly and ask their name. Two short bubbles read best — e.g. one bubble greeting them with `marhaban!` and introducing yourself as Mishmish, then a separate bubble asking their name.
+The learner has already seen a static greeting on screen before the conversation reaches you — three bubbles that read "marhaban!", "i'm mishmish, which means apricot in Arabic 😊", and "what is your name?". Do not repeat the greeting or re-introduce yourself. The learner's first message is their answer to "what is your name?" (a name, or a refusal). Acknowledge it warmly in one short bubble that uses their name, then ask about their motivation for learning Arabic.
 
 ## State so far
 What you have already collected (may be empty):

--- a/web-app/src/hooks/useOnboardingSession.ts
+++ b/web-app/src/hooks/useOnboardingSession.ts
@@ -9,6 +9,12 @@
  * The backend onboarding agent is goal-driven (no step machine): it gathers
  * what it needs at its own pace, then calls `generate_lessons` to render the
  * tile picker and mark onboarding complete.
+ *
+ * The hook is gated by `enabled` — passing `false` keeps it inert (no
+ * session, no WS, no token spend) so visitors who land but never interact
+ * cost nothing. Flip it to `true` once the learner submits their first
+ * message; any message sent before the WS is open is buffered and flushed
+ * on connect.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -27,17 +33,19 @@ export interface OnboardingSessionState {
   isAgentThinking: boolean;
 }
 
-export function useOnboardingSession(): OnboardingSessionState {
+export function useOnboardingSession(enabled: boolean): OnboardingSessionState {
   const supabase = useSupabase();
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [messages, setMessages] = useState<TranscriptMessage[]>([]);
   const [collected, setCollected] = useState<Record<string, unknown>>({});
   const [completed, setCompleted] = useState(false);
-  const [isAgentThinking, setIsAgentThinking] = useState(true);
+  const [isAgentThinking, setIsAgentThinking] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
+  const pendingSendRef = useRef<string | null>(null);
 
   useEffect(() => {
+    if (!enabled) return;
     let cancelled = false;
     let ws: WebSocket | null = null;
     let channel: ReturnType<typeof supabase.channel> | null = null;
@@ -102,6 +110,10 @@ export function useOnboardingSession(): OnboardingSessionState {
         ws.onopen = () => {
           if (cancelled) return;
           setReady(true);
+          if (pendingSendRef.current) {
+            ws!.send(pendingSendRef.current);
+            pendingSendRef.current = null;
+          }
         };
 
         ws.onmessage = (ev) => {
@@ -149,14 +161,18 @@ export function useOnboardingSession(): OnboardingSessionState {
       wsRef.current = null;
       if (channel) supabase.removeChannel(channel);
     };
-  }, [supabase]);
+  }, [enabled, supabase]);
 
   const sendMessage = useCallback((text: string) => {
-    const ws = wsRef.current;
     const trimmed = text.trim();
-    if (!ws || ws.readyState !== WebSocket.OPEN || !trimmed) return;
+    if (!trimmed) return;
     setIsAgentThinking(true);
-    ws.send(trimmed);
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(trimmed);
+    } else {
+      pendingSendRef.current = trimmed;
+    }
   }, []);
 
   return {

--- a/web-app/src/pages/Onboarding.tsx
+++ b/web-app/src/pages/Onboarding.tsx
@@ -302,6 +302,43 @@ function textToLine(text: string, highlights: Highlight[] | null | undefined, th
   return segs.length ? segs : [{ text, color: theme.ink }];
 }
 
+// Static greeting bubbles, shown to every new visitor without an LLM call.
+// These three lines are part of the brand experience — they're rendered
+// client-side so refreshes and idle visits cost zero tokens. The real
+// onboarding agent only spins up after the learner submits their first
+// message (their answer to "what is your name?").
+function buildInitialMessages(now: string): TranscriptMessage[] {
+  const stub = {
+    session_id: '',
+    user_id: '',
+    message_source: 'tutor' as const,
+    message_kind: 'text',
+    flow: 'onboarding',
+    created_at: now,
+    updated_at: now,
+  };
+  return [
+    {
+      ...stub,
+      message_id: 'mishmish:initial:0',
+      message_text: 'marhaban!',
+      highlights: [{ word: 'marhaban', meaning: 'hello', start: 0, end: 8 }],
+    },
+    {
+      ...stub,
+      message_id: 'mishmish:initial:1',
+      message_text: "i'm mishmish, which means apricot in Arabic \uD83D\uDE0A",
+      highlights: [{ word: 'mishmish', meaning: 'apricot', start: 4, end: 12 }],
+    },
+    {
+      ...stub,
+      message_id: 'mishmish:initial:2',
+      message_text: 'what is your name?',
+      highlights: null,
+    },
+  ];
+}
+
 export function Onboarding({ color = 'apricot' }: OnboardingProps) {
   const theme = THEMES[color];
   const [isMobile, setIsMobile] = useState(() =>
@@ -315,12 +352,25 @@ export function Onboarding({ color = 'apricot' }: OnboardingProps) {
     return () => window.removeEventListener('resize', onResize);
   }, []);
 
+  const [hasStarted, setHasStarted] = useState(false);
+  const initialMessages = useMemo(() => buildInitialMessages(new Date().toISOString()), []);
+
   const {
     error,
-    messages,
+    messages: liveMessages,
     sendMessage,
     isAgentThinking,
-  } = useOnboardingSession();
+  } = useOnboardingSession(hasStarted);
+
+  // Show the synthetic greeting bubbles only until any live message arrives.
+  // Once the agent has spoken (or the user message echoes back), we hand off
+  // entirely to the live messages — this avoids the failure mode where a
+  // tutor message lands via Realtime before its preceding user message and
+  // gets glued onto the synthetic "first turn" forever.
+  const messages = useMemo(
+    () => (liveMessages.length === 0 ? initialMessages : liveMessages),
+    [initialMessages, liveMessages],
+  );
 
   // The hero shows the agent's *current* turn — i.e. tutor messages that came
   // after the most recent user message. As soon as the learner submits, the
@@ -424,8 +474,9 @@ export function Onboarding({ color = 'apricot' }: OnboardingProps) {
 
   const handleSubmit = useCallback((msg: string) => {
     setSubmitPending(true);
+    if (!hasStarted) setHasStarted(true);
     sendMessage(msg);
-  }, [sendMessage]);
+  }, [hasStarted, sendMessage]);
 
   const handleLessonPick = useCallback((tile: LessonTile) => {
     sessionStorage.setItem('mishmish:onboarding:pick', tile.level.toLowerCase());


### PR DESCRIPTION
## Summary
- Onboarding's three greeting bubbles ("marhaban!", "i'm mishmish, which means apricot in Arabic 😊", "what is your name?") now render client-side as static text instead of being generated by the LLM on every WebSocket connect.
- The onboarding session, WebSocket, and agent only spin up once the learner submits their first message — idle visits and refreshes cost zero tokens and create no DB rows.
- The agent's system prompt was updated so it knows the greeting was already shown and opens by acknowledging the learner's name + asking about motivation, rather than reintroducing itself.

## Why
Two problems with the previous behavior:
1. **Cost**: every page visit and refresh fired `fire_opener` and paid for an LLM call to produce a near-identical greeting.
2. **Brand control**: the first impression was up to the model — phrasing drifted between visits and was harder to tighten.

## Implementation notes
- `web-api/agent/onboarding/onboarding_agent.py`: `fire_opener=False`; removed the now-dead `user_none_system_prompt`.
- `web-api/agent/onboarding/system.md`: rewrote the "Opening turn" section so the agent expects the learner's first message to be their name.
- `web-app/src/hooks/useOnboardingSession.ts`: added an `enabled` parameter that gates the entire effect, plus a small pending-send buffer that flushes on `ws.onopen` so the user's first submission isn't dropped during the connection handshake.
- `web-app/src/pages/Onboarding.tsx`: builds three synthetic `TranscriptMessage`s for the static greeting and uses them as `messages` until any live message arrives, at which point the existing turn-slicing / cross-fade logic takes over. (Picking *either* the synthetic set *or* the live set — never merging the two — avoids a Realtime ordering race where a tutor message arriving before its preceding user message would otherwise glue itself onto the synthetic "first turn".)

## Test plan
- [x] Cold visit `/onboarding` while signed in → no `POST /sessions`, no WebSocket upgrade, three greeting lines visible (verified via network tab).
- [x] Type a name and submit → `/sessions` POST fires, WS opens, agent reply *"Lovely to meet you, Tanya! What is drawing you to learn Arabic?…"* arrives without re-greeting; static lines fade out cleanly.
- [x] Submit a motivation → agent calls `generate_lessons` and renders three personalized LessonTiles.
- [x] `npx tsc --noEmit` in `web-app/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)