### PR TITLE
test(storybook): unblock stories with QueryClientProvider and /config stub

### DIFF
--- a/web-app/.storybook/preview.tsx
+++ b/web-app/.storybook/preview.tsx
@@ -2,11 +2,33 @@ import React from "react"
 import { ChakraProvider } from "@chakra-ui/react"
 import { withThemeByClassName } from "@storybook/addon-themes"
 import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { Preview } from '@storybook/react-vite'
 import { SupabaseProvider } from '../src/context/SupabaseContext'
 import { AuthProvider } from '../src/context/AuthContext'
 import { system } from '../src/theme'
 import '../src/index.css'
+
+// Stub /config so SupabaseProvider resolves without a running web-api.
+const realFetch = window.fetch.bind(window)
+window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+  if (url.endsWith('/config')) {
+    return Promise.resolve(new Response(JSON.stringify({
+      supabase_url: 'http://localhost:54321',
+      supabase_publishable_key: 'storybook-publishable-key',
+      posthog_key: '',
+      posthog_host: '',
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+  }
+  return realFetch(input, init)
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false, staleTime: Infinity },
+  },
+})
 
 const preview: Preview = {
   parameters: {
@@ -36,13 +58,15 @@ const preview: Preview = {
       const initialEntries = (context.parameters?.initialEntries as string[] | undefined) ?? ['/'];
       return (
         <ChakraProvider value={system}>
-          <SupabaseProvider>
-            <AuthProvider>
-              <MemoryRouter initialEntries={initialEntries}>
-                <Story />
-              </MemoryRouter>
-            </AuthProvider>
-          </SupabaseProvider>
+          <QueryClientProvider client={queryClient}>
+            <SupabaseProvider>
+              <AuthProvider>
+                <MemoryRouter initialEntries={initialEntries}>
+                  <Story />
+                </MemoryRouter>
+              </AuthProvider>
+            </SupabaseProvider>
+          </QueryClientProvider>
         </ChakraProvider>
       );
     },


### PR DESCRIPTION
## Summary
- Wrap every Storybook story in a `QueryClientProvider` so components using `useQuery` (e.g. `UsageMeter` via `usePlan`) no longer crash with "No QueryClient set."
- Intercept the `/config` fetch in `.storybook/preview.tsx` and return a stub payload, so `SupabaseProvider` resolves and pages (HomePage, Onboarding, Landing) render without a running web-api.
- Run `npm install` in `emails/` so Vite can resolve `@react-email/components` for the email stories.

## Why
Running `npm run storybook` against the existing stories surfaced two regressions:
1. Vite dependency-scan failure: `@react-email/components` was unresolved because `emails/` had never been installed.
2. Page-level stories failed at runtime: `UsageMeter` threw "No QueryClient set," and `SupabaseProvider`'s `init()` couldn't reach `localhost:8000/config`, so pages rendered the "Failed to load app configuration" fallback instead of the page itself.

Both are Storybook-only concerns — the production app already wires up `QueryClientProvider` and a real `/config` endpoint.

## Test plan
- [x] `npm run storybook` starts without the Vite dependency-scan error.
- [x] All 55 stories render without a visible Storybook error overlay.
- [x] `Pages/HomePage`, `Pages/Onboarding`, `Pages/Landing` render their actual UI (header, transcript, etc.) instead of the "Failed to load app configuration" fallback.
- [x] No `No QueryClient set` console errors when navigating between stories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)