### PR TITLE
feat(web-app): add pricing link to onboarding/landing top bar

### DIFF
--- a/web-app/src/pages/Landing.tsx
+++ b/web-app/src/pages/Landing.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type SVGProps } from 'react';
+import { Link } from 'react-router-dom';
 import { useStore } from '@/store';
 import { useTranscriptMessages } from '@/hooks/useTranscriptMessages';
 import { useSupabase } from '@/context/SupabaseContext';
@@ -649,15 +650,23 @@ export function TopBar({ theme, isMobile, isReturning }: { theme: Theme; isMobil
           color: theme.ink, letterSpacing: '-0.02em',
         }}>mishmish</span>
       </div>
-      <button style={{
-        background: 'transparent', color: theme.sub, border: `1px solid ${theme.border}`,
-        borderRadius: 999, fontSize: 13, cursor: 'pointer',
-        padding: '7px 14px 7px 11px', fontFamily: 'inherit',
-        display: 'inline-flex', alignItems: 'center', gap: 7,
-      }}>
-        {isReturning ? <Icon.settings width={14} height={14} /> : <Icon.user width={14} height={14} />}
-        {isReturning ? 'Settings' : 'Sign in'}
-      </button>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+        <Link to="/pricing" style={{
+          color: theme.sub, fontSize: 13, fontFamily: 'inherit',
+          textDecoration: 'none', padding: '7px 12px', borderRadius: 999,
+        }}>
+          Pricing
+        </Link>
+        <button style={{
+          background: 'transparent', color: theme.sub, border: `1px solid ${theme.border}`,
+          borderRadius: 999, fontSize: 13, cursor: 'pointer',
+          padding: '7px 14px 7px 11px', fontFamily: 'inherit',
+          display: 'inline-flex', alignItems: 'center', gap: 7,
+        }}>
+          {isReturning ? <Icon.settings width={14} height={14} /> : <Icon.user width={14} height={14} />}
+          {isReturning ? 'Settings' : 'Sign in'}
+        </button>
+      </div>
     </div>
   );
 }

--- a/web-app/src/pages/PricingPage.stories.tsx
+++ b/web-app/src/pages/PricingPage.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import PricingPage from './PricingPage';
+
+const meta = {
+  title: 'Pages/PricingPage',
+  component: PricingPage,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof PricingPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
## Summary
- Add a **Pricing** link to the `TopBar` shared by the onboarding and landing (returning-user) pages so visitors can reach `/pricing` from the marketing surfaces, not just the authenticated `Header`.
- Add a Storybook story for `PricingPage` under **Pages**, alongside `HomePage`, `Landing`, and `Onboarding`.

## Why
The existing `Pricing` button in `components/Header/Header.tsx` only renders on routes that mount `<Header />` (e.g. `/home`, `/pricing`). Onboarding and Landing render their own `TopBar` and previously had no entry point to pricing. PricingPage was also missing from Storybook's Pages section.

## Test plan
- [x] Onboarding (`/onboarding`) and Landing (`/landing`) both show **Pricing** in the top bar.
- [x] Clicking **Pricing** SPA-navigates to `/pricing` (uses `react-router-dom` `Link`, no full reload).
- [x] Storybook → `Pages/PricingPage/Default` renders the full pricing layout.
- [x] No new console errors on either page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)