### PR TITLE
feat(web-api): add duroos hand-off bubble before lesson tiles

### DIFF
--- a/web-api/agent/onboarding/system.md
+++ b/web-api/agent/onboarding/system.md
@@ -5,7 +5,7 @@ Gather two pieces of information so we can recommend starter lessons:
 1. The learner's **name** (first name is enough).
 2. Their **motivation** — what is drawing them to Arabic? (travel, family heritage, religion, work, partner, idle curiosity, etc.)
 
-Once you have both (or have respectfully recorded a refusal as the value), call `generate_lessons` exactly once. The tiles are the closing moment — produce no further text.
+Once you have both (or have respectfully recorded a refusal as the value), send one last short bubble that hands off to the lesson picker — use the Arabic word **duroos** (lessons, plural of *dars*) in place of the English word, and highlight it so its meaning shows on hover. e.g. `say("why don't we start with one of these duroos?", highlights=[{word: "duroos", meaning: "lessons"}])`. Then call `generate_lessons` exactly once. The tiles are the closing moment — produce no further text after that call.
 
 ## Tools
 - `say(text, highlights?)` — emit one chat bubble. Call this for everything visible to the learner. Multi-bubble turns are encouraged when it reads more naturally (greeting + question on its own line, etc.). Do NOT emit text via `final_output` — only `say`.
@@ -16,7 +16,7 @@ Once you have both (or have respectfully recorded a refusal as the value), call 
 - Be genuinely warm and specific. Reflect back what the learner said rather than generic "that's nice".
 - Never interrogate. If the learner declines to share something, accept it warmly and move on.
 - Never invent facts the learner didn't say. Never mention tools, schemas, or your own internal process.
-- Highlight Arabic interjections with the `highlights` argument so their meaning shows on hover. Example for `text="marhaban! i'm mishmish"`: `[{word:"marhaban", meaning:"hello", start:0, end:8}, {word:"mishmish", meaning:"apricot", start:17, end:25}]`.
+- Highlight Arabic interjections with the `highlights` argument so their meaning shows on hover. Each entry is just `{word, meaning}` — character offsets are computed server-side from the literal `word`, so it must appear verbatim in `text`. Example for `text="marhaban! i'm mishmish"`: `[{word: "marhaban", meaning: "hello"}, {word: "mishmish", meaning: "apricot"}]`.
 
 ## Language
 Write in **English**. A single Arabic interjection (marhaban, ahlan, mumtaz, mashallah) is welcome as flavour, but the line itself must be English. Do not write full Arabic sentences and never use Arabic script — the learner does not speak Arabic yet. You are the welcoming face of Arabic learning, not yet a lesson.

--- a/web-api/agent/onboarding/tools/say_tool.py
+++ b/web-api/agent/onboarding/tools/say_tool.py
@@ -18,8 +18,6 @@ class Highlight(BaseModel):
     """Word-level annotation rendered as a hoverable tinted span."""
     word: str
     meaning: str
-    start: int
-    end: int
 
 
 @function_tool
@@ -38,17 +36,32 @@ async def say(
             may appear as flavour but the line is otherwise English. Never
             output Arabic script or a full Arabic sentence.
         highlights: Optional word annotations. Each entry carries the literal
-            `word`, its English `meaning`, and the character offsets (`start`,
-            `end`) within `text`. Mark Arabic interjections this way so the
-            UI shows their meaning on hover.
+            `word` (must appear verbatim in `text`) and its English `meaning`.
+            Mark Arabic interjections this way so the UI shows their meaning
+            on hover. Character offsets are computed server-side from `word`.
     """
     app_context = context.context
+
+    resolved: list[dict] = []
+    for h in highlights or []:
+        idx = text.find(h.word)
+        if idx < 0:
+            continue
+        resolved.append(
+            {
+                "word": h.word,
+                "meaning": h.meaning,
+                "start": idx,
+                "end": idx + len(h.word),
+            }
+        )
+
     await create_transcript_message(
         session_id=app_context.session_id,
         message_source="tutor",
         message_kind="transcript",
         message_text=text,
-        highlights=[h.model_dump() for h in (highlights or [])],
+        highlights=resolved,
         flow="onboarding",
     )
     return "ok"


### PR DESCRIPTION
## Summary
- After acknowledging the learner's motivation, the onboarding agent now sends one final transitional bubble — e.g. *"why don't we start with one of these **duroos**?"* — using the Arabic word for "lessons" with a hover tooltip, before rendering the lesson tile picker. Reinforces the brand's "your tutor speaks Arabic, and you can pick up a word at a time" feel right at the moment we hand the conversation off to a UI.
- Drops \`start\`/\`end\` from the \`say\` tool's \`Highlight\` schema. Agent now provides only \`{word, meaning}\` and the server computes offsets via \`text.find(word)\`. First time around the agent rendered the highlight one character short on \`durūs\` (the LLM miscounted indices around the non-ASCII \`ū\`), so this also switches the suggested transliteration to plain-ASCII \`duroos\`.

## Test plan
- [x] Smoke-tested in browser preview: walked through onboarding (name → motivation → tiles). The hand-off bubble renders, \`duroos\` is fully highlighted, and the click/hover popover shows "lessons".
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)