### PR TITLE
feat(web-app): show sending state via input shine sweep and tinted text

### DIFF
--- a/web-app/src/pages/Landing.tsx
+++ b/web-app/src/pages/Landing.tsx
@@ -169,6 +169,7 @@ export function UserInput({ theme, isMobile, prefilled = null, autoFocus = true,
     <form
       onSubmit={handleSubmit}
       style={{
+        position: 'relative', overflow: 'hidden',
         marginTop: isMobile ? 4 : 8, background: theme.surface,
         border: `1.5px solid ${theme.tint}`,
         borderRadius: isMobile ? 18 : 22, padding: isMobile ? '16px 16px' : '22px 24px',
@@ -176,6 +177,20 @@ export function UserInput({ theme, isMobile, prefilled = null, autoFocus = true,
         boxShadow: `0 20px 40px -24px ${theme.tint}66, 0 0 0 4px ${theme.tintSoft}`,
       }}
     >
+      <style>{`@keyframes mmInputShine { 0% { transform: translateX(-100%); } 100% { transform: translateX(200%); } }`}</style>
+      {disabled && (
+        <span
+          aria-hidden="true"
+          style={{
+            position: 'absolute', inset: 0,
+            background: `linear-gradient(110deg, transparent 30%, ${theme.tint}cc 50%, transparent 70%)`,
+            transform: 'translateX(-100%)',
+            animation: 'mmInputShine 1.6s ease-in-out infinite',
+            pointerEvents: 'none',
+            mixBlendMode: 'screen',
+          }}
+        />
+      )}
       <input
         ref={inputRef}
         type="text"
@@ -185,8 +200,13 @@ export function UserInput({ theme, isMobile, prefilled = null, autoFocus = true,
         autoComplete="off"
         style={{
           flex: 1, minWidth: 0,
+          position: 'relative',
           fontFamily: FONT_STACK,
-          fontSize: isMobile ? 26 : 40, color: theme.ink,
+          fontSize: isMobile ? 26 : 40,
+          color: disabled ? theme.tint : theme.ink,
+          WebkitTextFillColor: disabled ? theme.tint : theme.ink,
+          opacity: 1,
+          transition: 'color .25s ease, -webkit-text-fill-color .25s ease',
           lineHeight: 1.1, letterSpacing: '-0.02em',
           fontWeight: 600,
           background: 'transparent', border: 'none', outline: 'none',
@@ -199,6 +219,7 @@ export function UserInput({ theme, isMobile, prefilled = null, autoFocus = true,
           disabled
           aria-label="Sending message"
           style={{
+            position: 'relative',
             width: isMobile ? 44 : 54, height: isMobile ? 44 : 54, borderRadius: '50%',
             background: theme.tint, color: '#fff', border: 'none', cursor: 'default',
             display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
@@ -213,6 +234,7 @@ export function UserInput({ theme, isMobile, prefilled = null, autoFocus = true,
           type="submit"
           aria-label="Send message"
           style={{
+            position: 'relative',
             width: isMobile ? 44 : 54, height: isMobile ? 44 : 54, borderRadius: '50%',
             background: theme.tint, color: '#fff', border: 'none', cursor: 'pointer',
             display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
@@ -227,6 +249,7 @@ export function UserInput({ theme, isMobile, prefilled = null, autoFocus = true,
           onClick={handleMicClick}
           aria-label="Start voice call"
           style={{
+            position: 'relative',
             width: isMobile ? 44 : 54, height: isMobile ? 44 : 54, borderRadius: '50%',
             background: theme.tint, color: '#fff', border: 'none', cursor: 'pointer',
             display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,

--- a/web-app/src/pages/Onboarding.tsx
+++ b/web-app/src/pages/Onboarding.tsx
@@ -497,7 +497,7 @@ export function Onboarding({ color = 'apricot' }: OnboardingProps) {
       WebkitFontSmoothing: 'antialiased',
       letterSpacing: '-0.01em',
     }}>
-      <style>{`@keyframes mmLandingBlink { 0%, 50% { opacity: 1 } 50.01%, 100% { opacity: 0 } } @keyframes mmOnboardingPulse { 0%, 100% { opacity: 0.35 } 50% { opacity: 1 } }`}</style>
+      <style>{`@keyframes mmLandingBlink { 0%, 50% { opacity: 1 } 50.01%, 100% { opacity: 0 } }`}</style>
       <TopBar theme={theme} isMobile={isMobile} isReturning={false} />
       <div style={{
         maxWidth: containerMax, margin: '0 auto',
@@ -534,20 +534,6 @@ export function Onboarding({ color = 'apricot' }: OnboardingProps) {
                 resetKey={displayTurnKey}
               />
             </div>
-
-            {/* Subtle "thinking" dot while the agent composes its reply */}
-            {isAgentThinking && !error && (
-              <div style={{
-                display: 'flex', alignItems: 'center', gap: 8, color: theme.sub,
-                fontSize: 13, letterSpacing: '0.02em',
-              }}>
-                <span style={{
-                  display: 'inline-block', width: 6, height: 6, borderRadius: '50%',
-                  background: theme.tint, animation: 'mmOnboardingPulse 1.2s ease-in-out infinite',
-                }} />
-                <span>mishmish is thinking…</span>
-              </div>
-            )}
 
             {componentMessages.map((m) => {
               const parsed = parseComponentMessage(m);

--- a/web-app/src/pages/UserInput.stories.tsx
+++ b/web-app/src/pages/UserInput.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { THEMES, UserInput } from './Landing';
+
+const meta = {
+  title: 'Pages/UserInput',
+  component: UserInput,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 720, padding: 24, background: THEMES.apricot.bg }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof UserInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Idle: Story = {
+  args: {
+    theme: THEMES.apricot,
+    isMobile: false,
+    prefilled: 'Tanya',
+    autoFocus: false,
+    onSubmit: () => {},
+    onMicClick: () => {},
+    disabled: false,
+  },
+};
+
+export const Sending: Story = {
+  args: {
+    theme: THEMES.apricot,
+    isMobile: false,
+    prefilled: 'Tanya',
+    autoFocus: false,
+    onSubmit: () => {},
+    onMicClick: () => {},
+    disabled: true,
+  },
+};


### PR DESCRIPTION
## Summary
- Replace the small "mishmish is thinking…" indicator under the onboarding hero with an in-input animation: a translucent diagonal shine sweeps across the whole text input while the agent is composing.
- Recolor just-submitted user text from `theme.ink` to `theme.tint` (and disable browser dimming via `WebkitTextFillColor` + `opacity: 1`) so the message visibly reads as "sent, no longer editable". Button-side spinner is unchanged.
- Add a `Pages/UserInput` Storybook with `Idle` and `Sending` variants for visual review.

## Test plan
- [ ] Open `Pages/UserInput` → `Sending` in Storybook and confirm the shine sweep + orange text.
- [ ] Open `Pages/UserInput` → `Idle` and confirm normal ink text and no animation.
- [ ] Run the onboarding flow end-to-end, submit a name, and confirm the input goes into the sending state until the agent reply arrives, then resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)