### PR TITLE
fix(web-app): use favicon.svg as logo across onboarding and password reset pages

### DIFF
--- a/web-app/src/pages/Landing.tsx
+++ b/web-app/src/pages/Landing.tsx
@@ -88,24 +88,6 @@ const Icon = {
   ),
 };
 
-function ApricotMark({ size = 26 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 40 40">
-      <defs>
-        <radialGradient id="apr-body-2" cx="35%" cy="30%" r="75%">
-          <stop offset="0%" stopColor="#FFD199" />
-          <stop offset="55%" stopColor="#F09B53" />
-          <stop offset="100%" stopColor="#B8501A" />
-        </radialGradient>
-      </defs>
-      <path d="M20 9 C12 9 6 15 6 23 C6 31 12 36 20 36 C28 36 34 31 34 23 C34 15 28 9 20 9 Z" fill="url(#apr-body-2)" />
-      <path d="M20 10 C19 14 19 30 20 36" stroke="rgba(155,63,16,0.35)" strokeWidth="1" fill="none" />
-      <path d="M20 10 C18 5 14 3 10 4 C11 8 15 11 20 10 Z" fill="#5DA34D" />
-      <ellipse cx="14" cy="17" rx="3.5" ry="2" fill="rgba(255,255,255,0.4)" />
-    </svg>
-  );
-}
-
 type TextSegment = { text: string; color: string };
 type ChipSegment = { chip: { ar: string; latin: string; meaning: string } };
 type Segment = TextSegment | ChipSegment;
@@ -644,7 +626,7 @@ export function TopBar({ theme, isMobile, isReturning }: { theme: Theme; isMobil
       WebkitBackdropFilter: 'blur(10px)',
     }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
-        <ApricotMark size={26} />
+        <img src="/favicon.svg" alt="mishmish.ai logo" width={26} height={26} />
         <span style={{
           fontFamily: FONT_STACK, fontSize: 20, fontWeight: 700,
           color: theme.ink, letterSpacing: '-0.02em',

--- a/web-app/src/pages/auth/ForgotPassword.tsx
+++ b/web-app/src/pages/auth/ForgotPassword.tsx
@@ -67,7 +67,7 @@ const ForgotPassword: React.FC = () => {
     <VStack gap={6}>
       <Box textAlign="center" pt={6}>
         <Image
-          src="/logo.svg"
+          src="/favicon.svg"
           alt="🍑 mishmish.ai"
           h={32}
           mx="auto"

--- a/web-app/src/pages/auth/ResetPassword.tsx
+++ b/web-app/src/pages/auth/ResetPassword.tsx
@@ -208,7 +208,7 @@ const ResetPassword: React.FC = () => {
     <VStack gap={6}>
       <Box textAlign="center" pt={6}>
         <Image
-          src="/logo.svg"
+          src="/favicon.svg"
           alt="🍑 mishmish.ai"
           h={32}
           mx="auto"


### PR DESCRIPTION
## Summary
- Onboarding/landing TopBar now uses `/favicon.svg` instead of a custom inline `ApricotMark` SVG, and the unused component has been removed
- Password reset and forgot-password pages now use `/favicon.svg` instead of the non-existent `/logo.svg` (the image was previously broken)
- Result: every header/auth page renders the same 🍑 brand mark

## Test plan
- [x] `/onboarding` and `/landing` TopBar shows the favicon next to "mishmish"
- [x] Existing-user header on `/` continues to render the favicon
- [x] `/forgot-password` page renders the favicon (previously broken)
- [ ] Verify `/reset-password` renders the favicon (uses identical markup to forgot-password)

🤖 Generated with [Claude Code](https://claude.com/claude-code)