### PR TITLE
fix: serialize Caddyfile updates in preview deploys

### DIFF
--- a/.github/workflows/_deploy-preview-api.yml
+++ b/.github/workflows/_deploy-preview-api.yml
@@ -182,6 +182,8 @@ jobs:
             exit 1
           fi
 
+      # Concurrent PR deploys race on /etc/caddy/Caddyfile, so we serialize via flock
+      # and roll back on reload failure to avoid leaving a corrupt config on disk.
       - name: Configure API Caddy route via SSM
         run: |
           PR_NUM="${{ inputs.pr_number }}"
@@ -193,14 +195,19 @@ jobs:
           set -euo pipefail
           echo "=== Configuring API Caddy route for PR #$PR_NUM at \$(date) ==="
 
-          # Remove old API block if exists
-          sed -i '/^# BEGIN api-pr-${PR_NUM}\$/,/^# END api-pr-${PR_NUM}\$/d' /etc/caddy/Caddyfile
+          (
+            flock -x -w 60 9
+            BACKUP=/etc/caddy/Caddyfile.bak.api-pr-${PR_NUM}
+            cp /etc/caddy/Caddyfile "\$BACKUP"
 
-          # Also remove legacy monolithic block (from before selective deploys)
-          sed -i '/^# BEGIN pr-${PR_NUM}\$/,/^# END pr-${PR_NUM}\$/d' /etc/caddy/Caddyfile
+            # Remove old API block if exists
+            sed -i '/^# BEGIN api-pr-${PR_NUM}\$/,/^# END api-pr-${PR_NUM}\$/d' /etc/caddy/Caddyfile
 
-          # Add API reverse proxy block
-          cat >> /etc/caddy/Caddyfile <<'CADDYEOF'
+            # Also remove legacy monolithic block (from before selective deploys)
+            sed -i '/^# BEGIN pr-${PR_NUM}\$/,/^# END pr-${PR_NUM}\$/d' /etc/caddy/Caddyfile
+
+            # Add API reverse proxy block
+            cat >> /etc/caddy/Caddyfile <<'CADDYEOF'
 
           # BEGIN api-pr-${PR_NUM}
           api-pr-${PR_NUM}.preview.mishmish.ai {
@@ -222,7 +229,16 @@ jobs:
           # END api-pr-${PR_NUM}
           CADDYEOF
 
-          systemctl reload caddy
+            if ! systemctl reload caddy; then
+              echo "caddy reload failed — restoring previous Caddyfile" >&2
+              cp "\$BACKUP" /etc/caddy/Caddyfile
+              systemctl reload caddy || true
+              rm -f "\$BACKUP"
+              exit 1
+            fi
+            rm -f "\$BACKUP"
+          ) 9>/var/lock/caddy-update.lock
+
           echo "API Caddy route configured for PR #$PR_NUM"
           SCRIPT
 
@@ -231,22 +247,34 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "$INSTANCE_ID" \
             --document-name "AWS-RunShellScript" \
-            --timeout-seconds 120 \
+            --timeout-seconds 180 \
             --parameters "{\"commands\":$COMMANDS_JSON}" \
             --query "Command.CommandId" --output text)
+          echo "SSM Command ID: $COMMAND_ID"
 
-          aws ssm wait command-executed \
-            --command-id "$COMMAND_ID" \
-            --instance-id "$INSTANCE_ID" || true
-
-          RESULT=$(aws ssm get-command-invocation \
-            --command-id "$COMMAND_ID" \
-            --instance-id "$INSTANCE_ID" \
-            --query "Status" --output text)
+          # Poll until the command reaches a terminal state or we hit ~3 min.
+          # Avoids `aws ssm wait` returning stale "Pending" when its 100s default expires.
+          RESULT=Pending
+          for i in $(seq 1 60); do
+            RESULT=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query "Status" --output text)
+            case "$RESULT" in
+              Success|Failed|Cancelled|TimedOut) break ;;
+            esac
+            sleep 3
+          done
 
           echo "API Caddy config status: $RESULT"
           if [ "$RESULT" != "Success" ]; then
-            echo "::error::API Caddy config failed"
+            echo "::error::API Caddy config failed (status: $RESULT)"
+            echo "--- StandardOutputContent ---"
+            aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query "StandardOutputContent" --output text
+            echo "--- StandardErrorContent ---"
             aws ssm get-command-invocation \
               --command-id "$COMMAND_ID" \
               --instance-id "$INSTANCE_ID" \

--- a/.github/workflows/_deploy-preview-static-sites.yml
+++ b/.github/workflows/_deploy-preview-static-sites.yml
@@ -108,7 +108,9 @@ jobs:
             --distribution-id "${{ steps.preview-infra.outputs.dist_id }}" \
             --paths "/pr-${PR_NUM}/*"
 
-      # Configure Caddy to route frontend preview subdomains via shared CloudFront
+      # Configure Caddy to route frontend preview subdomains via shared CloudFront.
+      # Concurrent PR deploys race on /etc/caddy/Caddyfile, so we serialize via flock
+      # and roll back on reload failure to avoid leaving a corrupt config on disk.
       - name: Configure frontend Caddy routes via SSM
         run: |
           PR_NUM="${{ inputs.pr_number }}"
@@ -120,11 +122,16 @@ jobs:
           set -euo pipefail
           echo "=== Configuring frontend Caddy routes for PR #$PR_NUM at \$(date) ==="
 
-          # Remove old frontend block if exists
-          sed -i '/^# BEGIN web-pr-${PR_NUM}\$/,/^# END web-pr-${PR_NUM}\$/d' /etc/caddy/Caddyfile
+          (
+            flock -x -w 60 9
+            BACKUP=/etc/caddy/Caddyfile.bak.web-pr-${PR_NUM}
+            cp /etc/caddy/Caddyfile "\$BACKUP"
 
-          # Add frontend reverse proxy blocks with path rewriting
-          cat >> /etc/caddy/Caddyfile <<'CADDYEOF'
+            # Remove old frontend block if exists
+            sed -i '/^# BEGIN web-pr-${PR_NUM}\$/,/^# END web-pr-${PR_NUM}\$/d' /etc/caddy/Caddyfile
+
+            # Add frontend reverse proxy blocks with path rewriting
+            cat >> /etc/caddy/Caddyfile <<'CADDYEOF'
 
           # BEGIN web-pr-${PR_NUM}
           pr-${PR_NUM}.preview.mishmish.ai {
@@ -142,7 +149,16 @@ jobs:
           # END web-pr-${PR_NUM}
           CADDYEOF
 
-          systemctl reload caddy
+            if ! systemctl reload caddy; then
+              echo "caddy reload failed — restoring previous Caddyfile" >&2
+              cp "\$BACKUP" /etc/caddy/Caddyfile
+              systemctl reload caddy || true
+              rm -f "\$BACKUP"
+              exit 1
+            fi
+            rm -f "\$BACKUP"
+          ) 9>/var/lock/caddy-update.lock
+
           echo "Frontend Caddy routes configured for PR #$PR_NUM"
           SCRIPT
 
@@ -151,22 +167,34 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "$INSTANCE_ID" \
             --document-name "AWS-RunShellScript" \
-            --timeout-seconds 120 \
+            --timeout-seconds 180 \
             --parameters "{\"commands\":$COMMANDS_JSON}" \
             --query "Command.CommandId" --output text)
+          echo "SSM Command ID: $COMMAND_ID"
 
-          aws ssm wait command-executed \
-            --command-id "$COMMAND_ID" \
-            --instance-id "$INSTANCE_ID" || true
-
-          RESULT=$(aws ssm get-command-invocation \
-            --command-id "$COMMAND_ID" \
-            --instance-id "$INSTANCE_ID" \
-            --query "Status" --output text)
+          # Poll until the command reaches a terminal state or we hit ~3 min (60 * 3s).
+          # Avoids `aws ssm wait` returning stale "Pending" when its 100s default expires.
+          RESULT=Pending
+          for i in $(seq 1 60); do
+            RESULT=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query "Status" --output text)
+            case "$RESULT" in
+              Success|Failed|Cancelled|TimedOut) break ;;
+            esac
+            sleep 3
+          done
 
           echo "Frontend Caddy config status: $RESULT"
           if [ "$RESULT" != "Success" ]; then
-            echo "::error::Frontend Caddy config failed"
+            echo "::error::Frontend Caddy config failed (status: $RESULT)"
+            echo "--- StandardOutputContent ---"
+            aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query "StandardOutputContent" --output text
+            echo "--- StandardErrorContent ---"
             aws ssm get-command-invocation \
               --command-id "$COMMAND_ID" \
               --instance-id "$INSTANCE_ID" \

--- a/.github/workflows/destroy-preview.yml
+++ b/.github/workflows/destroy-preview.yml
@@ -37,7 +37,8 @@ jobs:
             exit 0
           fi
 
-          # Write cleanup script
+          # Write cleanup script. Caddyfile edits are wrapped in flock to avoid
+          # racing with concurrent deploy-preview runs (different PRs share the file).
           cat > /tmp/cleanup.sh <<SCRIPT
           #!/bin/bash
           set -euo pipefail
@@ -47,13 +48,25 @@ jobs:
           docker stop pr-${PR_NUM} 2>/dev/null || true
           docker rm pr-${PR_NUM} 2>/dev/null || true
 
-          # Remove Caddy config blocks (all marker variants)
-          sed -i '/^# BEGIN pr-${PR_NUM}$/,/^# END pr-${PR_NUM}$/d' /etc/caddy/Caddyfile
-          sed -i '/^# BEGIN api-pr-${PR_NUM}$/,/^# END api-pr-${PR_NUM}$/d' /etc/caddy/Caddyfile
-          sed -i '/^# BEGIN web-pr-${PR_NUM}$/,/^# END web-pr-${PR_NUM}$/d' /etc/caddy/Caddyfile
+          (
+            flock -x -w 60 9
+            BACKUP=/etc/caddy/Caddyfile.bak.cleanup-pr-${PR_NUM}
+            cp /etc/caddy/Caddyfile "\$BACKUP"
 
-          # Reload Caddy
-          systemctl reload caddy
+            # Remove Caddy config blocks (all marker variants)
+            sed -i '/^# BEGIN pr-${PR_NUM}\$/,/^# END pr-${PR_NUM}\$/d' /etc/caddy/Caddyfile
+            sed -i '/^# BEGIN api-pr-${PR_NUM}\$/,/^# END api-pr-${PR_NUM}\$/d' /etc/caddy/Caddyfile
+            sed -i '/^# BEGIN web-pr-${PR_NUM}\$/,/^# END web-pr-${PR_NUM}\$/d' /etc/caddy/Caddyfile
+
+            if ! systemctl reload caddy; then
+              echo "caddy reload failed — restoring previous Caddyfile" >&2
+              cp "\$BACKUP" /etc/caddy/Caddyfile
+              systemctl reload caddy || true
+              rm -f "\$BACKUP"
+              exit 1
+            fi
+            rm -f "\$BACKUP"
+          ) 9>/var/lock/caddy-update.lock
 
           # Clean up env file
           rm -f /etc/mishmish/pr-${PR_NUM}.env
@@ -66,22 +79,40 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "$INSTANCE_ID" \
             --document-name "AWS-RunShellScript" \
-            --timeout-seconds 120 \
+            --timeout-seconds 180 \
             --parameters "{\"commands\":$COMMANDS_JSON}" \
             --query "Command.CommandId" --output text)
 
           echo "SSM Command ID: $COMMAND_ID"
 
-          aws ssm wait command-executed \
-            --command-id "$COMMAND_ID" \
-            --instance-id "$INSTANCE_ID" || true
-
-          RESULT=$(aws ssm get-command-invocation \
-            --command-id "$COMMAND_ID" \
-            --instance-id "$INSTANCE_ID" \
-            --query "Status" --output text)
+          # Poll until terminal state or ~3 min, instead of relying on `aws ssm wait`
+          # which silently returns at its 100s default and leaves status as Pending.
+          RESULT=Pending
+          for i in $(seq 1 60); do
+            RESULT=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query "Status" --output text)
+            case "$RESULT" in
+              Success|Failed|Cancelled|TimedOut) break ;;
+            esac
+            sleep 3
+          done
 
           echo "Container cleanup status: $RESULT"
+          if [ "$RESULT" != "Success" ]; then
+            echo "::warning::Cleanup did not complete cleanly (status: $RESULT)"
+            echo "--- StandardOutputContent ---"
+            aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query "StandardOutputContent" --output text
+            echo "--- StandardErrorContent ---"
+            aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query "StandardErrorContent" --output text
+          fi
 
       # Delete this PR's files from the shared preview bucket
       - name: Delete preview static files


### PR DESCRIPTION
## Summary

- Wrap each `/etc/caddy/Caddyfile` update in a `flock`-guarded subshell so concurrent preview deploys can't race on the shared file
- Back up the Caddyfile before edits and restore it if `caddy reload` fails — prevents a broken config from persisting on disk and breaking all subsequent deploys
- Replace `aws ssm wait command-executed || true` (which silently returned at its 100s default and reported stale "Pending" status) with a 3-minute polling loop
- Print `StandardOutputContent` alongside `StandardErrorContent` on failure so future SSM script errors aren't invisible

## Why

`deploy-static-sites` for PRs has been failing intermittently. Investigation of recent runs showed two failure modes:

1. **`Frontend Caddy config status: Failed`** — the SSM script itself returned non-zero. The displayed `StandardErrorContent` was empty, so the actual cause was hidden. Most likely: concurrent SSM commands from other PR deploys racing on `sed -i` / `cat >>` corrupted the Caddyfile, then `systemctl reload caddy` failed.
2. **`Frontend Caddy config status: Pending`** — `aws ssm wait command-executed` timed out at its 100s default before the command finished, but the `|| true` swallowed the error and we proceeded with stale status.

Both deploy-preview-api, deploy-preview-static-sites, and destroy-preview share the Caddyfile on the same EC2 host, so the same fix applies to all three.

## Test plan

- [ ] This PR's own `Deploy (Preview)` run uses the new code — if it succeeds, the fix is exercised end-to-end
- [ ] Open another PR concurrently to confirm two deploys don't break each other
- [ ] If a future SSM failure occurs, confirm both stdout and stderr are now printed in the workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)