### PR TITLE
feat(web-app): lengthen onboarding hero line gap to 500ms

### DIFF
--- a/web-app/src/pages/Onboarding.tsx
+++ b/web-app/src/pages/Onboarding.tsx
@@ -104,7 +104,7 @@ function TypingHero({ lines, isMobile, theme, resetKey }: {
       } else if (i === carriedCount) {
         lineStart[i] = startAt;
       } else {
-        lineStart[i] = lineStart[i - 1] + lineDur[i - 1] + 200;
+        lineStart[i] = lineStart[i - 1] + lineDur[i - 1] + 500;
       }
     }
 


### PR DESCRIPTION
## Summary
- Bumps the inter-line delay in `TypingHero` (Onboarding) from 200ms to 500ms so each typed greeting line breathes for half a second before the next one starts.

## Why
The previous 200ms gap made the three greeting bubbles feel like one block of text being dumped in. A 500ms beat between lines gives readers time to register each line before the next begins.

## Test plan
- [ ] Visit `/onboarding` on a fresh load and confirm each line waits ~500ms after the previous one finishes typing before the next begins.
- [ ] Confirm the cursor still blinks on the active line and disappears once all lines are typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)