### PR TITLE
ci: allow onboarding as a PR title scope

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -38,6 +38,7 @@ jobs:
             config
             main
             claude
+            onboarding
           requireScope: false
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: >


### PR DESCRIPTION
## Summary

Adds `onboarding` to the `action-semantic-pull-request` scope allowlist so cross-cutting changes to the onboarding flow (web-api agent + web-app page) can be titled with that scope rather than picking one package.

Carved out from #175 so it can land on `main` first — `pr-checks.yml` runs on `pull_request_target`, which reads the workflow file from the base branch, so #175 can't validate against its own workflow change.

## Test plan

- [x] After merge, re-run PR Checks on #175 to confirm `refactor(onboarding): ...` passes validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)