### PR TITLE
feat: introduce lessons table with propose/generate flow

### DIFF
--- a/supabase/migrations/20260427120000_add_lessons.sql
+++ b/supabase/migrations/20260427120000_add_lessons.sql
@@ -1,0 +1,110 @@
+-- Lookup of lesson formats and the table + handler each one is wired to.
+-- Seeded with 'flashcards' (the only format wired end-to-end in this round);
+-- new formats slot in by adding a row + a generator module.
+CREATE TABLE public.lesson_formats (
+  slug              text PRIMARY KEY,
+  display_name      text NOT NULL,
+  content_table     text NOT NULL,
+  generator_handler text NOT NULL,
+  enabled           boolean NOT NULL DEFAULT true,
+  created_at        timestamp with time zone NOT NULL DEFAULT now()
+);
+
+INSERT INTO public.lesson_formats (slug, display_name, content_table, generator_handler) VALUES
+  ('flashcards', 'Flashcards', 'flashcard_sets', 'agent.tutor.tools.generators.flashcards.generate');
+
+-- Umbrella table: one row per proposed (and possibly generated) lesson.
+-- A "proposal group" is the set of rows sharing a proposal_group_id, which is
+-- everything emitted from a single propose_lessons tool call.
+CREATE TABLE public.lessons (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  proposal_group_id   uuid NOT NULL,
+  created_by          uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  session_id          text REFERENCES public.agent_sessions(session_id) ON DELETE SET NULL,
+
+  title               text NOT NULL,
+  blurb               text NOT NULL,
+  arabic_preview      text,
+
+  format              text NOT NULL REFERENCES public.lesson_formats(slug),
+  generation_hints    jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Polymorphic content link, populated when the lesson reaches `ready`.
+  content_table       text,
+  content_id          uuid,
+
+  status              text NOT NULL DEFAULT 'proposed'
+                       CHECK (status IN ('proposed','dismissed','generating','ready','in_progress','completed','failed','archived')),
+  error               text,
+
+  started_at          timestamp with time zone,
+  completed_at        timestamp with time zone,
+  created_at          timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at          timestamp with time zone NOT NULL DEFAULT now(),
+
+  CONSTRAINT lessons_content_pair_xor
+    CHECK ((content_table IS NULL AND content_id IS NULL)
+        OR (content_table IS NOT NULL AND content_id IS NOT NULL))
+);
+
+CREATE INDEX idx_lessons_creator ON public.lessons(created_by);
+CREATE INDEX idx_lessons_group   ON public.lessons(proposal_group_id);
+CREATE INDEX idx_lessons_status  ON public.lessons(status);
+CREATE INDEX idx_lessons_content ON public.lessons(content_table, content_id);
+
+-- Permissions
+GRANT ALL ON public.lessons TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.lessons TO authenticated;
+
+GRANT ALL ON public.lesson_formats TO service_role;
+GRANT SELECT ON public.lesson_formats TO authenticated;
+GRANT SELECT ON public.lesson_formats TO anon;
+
+-- RLS
+ALTER TABLE public.lessons ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.lesson_formats ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Owners can manage their own lessons"
+  ON public.lessons
+  FOR ALL
+  TO authenticated
+  USING (auth.uid() = created_by)
+  WITH CHECK (auth.uid() = created_by);
+
+CREATE POLICY "Service role has full access to lessons"
+  ON public.lessons
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "Anyone can read lesson formats"
+  ON public.lesson_formats
+  FOR SELECT
+  TO authenticated, anon
+  USING (true);
+
+CREATE POLICY "Service role has full access to lesson formats"
+  ON public.lesson_formats
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Auto-update updated_at on lessons
+CREATE OR REPLACE FUNCTION public.update_lessons_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_lessons_updated_at
+  BEFORE UPDATE ON public.lessons
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_lessons_updated_at();
+
+-- Realtime: clients subscribe to lessons rows by proposal_group_id for the
+-- proposal-tile picker, and to individual rows to track generation progress.
+ALTER PUBLICATION supabase_realtime ADD TABLE lessons;

--- a/web-api/agent/tutor/languages/ar-AR.md
+++ b/web-api/agent/tutor/languages/ar-AR.md
@@ -42,10 +42,11 @@ Response: "مُمْتَاز! شُو أَكْلَتَكَ المُفَضَّلَ�
 
 
 ## Flashcards
-- If the user asks to learn a collection of vocabulary (e.g. "teach me the days of the week", "what are the colours", "teach me months", "common foods", "winter clothing", "animals", "body parts", "numbers"), use the generate_flashcards tool
-- Generate a COMPLETE set of cards for the collection — include all items, not just a few
-- Each card must have accurate Arabic with full harakaat, a transliteration, and the English translation
-- After calling the tool, acknowledge that the flashcards are being generated with a brief spoken response in Arabic
+- If the user explicitly asks for a specific deck right now (e.g. "teach me the days of the week", "give me flashcards for colours"), use the generate_flashcards tool directly
+- If the user expresses a broader interest you could build practice around (e.g. "I want to talk about food", "help me with travel vocabulary"), use propose_lessons to offer 2-4 options first; do NOT also call generate_lesson_content in the same turn — wait for the user to pick
+- When the user picks a tile, call generate_lesson_content with the lesson_id from the propose_lessons confirmation, then stop talking and let the lesson speak for itself
+- For every lesson (direct or proposed), produce a COMPLETE card list — all items, with full harakaat on the Arabic, a transliteration, and the English translation
+- After calling the tool, acknowledge briefly in Arabic that the lesson is being prepared
 
 ## Audio Pronunciation
 - If the user asks how to pronounce a word, phrase, or anything from the conversation, use the send_audio tool

--- a/web-api/agent/tutor/tools/flashcards_tool.py
+++ b/web-api/agent/tutor/tools/flashcards_tool.py
@@ -1,4 +1,14 @@
-"""Tool for generating flashcard sets for vocabulary collections."""
+"""Tool for generating flashcard sets for vocabulary collections.
+
+Direct/bypass path: the tutor can drop a flashcard deck mid-conversation
+without going through the propose -> pick -> generate cycle. Each call still
+creates a `lessons` row (in `status='ready'`) alongside the flashcard set so
+the `lessons` table remains the single source of truth for "what content
+does this user have".
+
+For the deliberate two-step flow (propose then generate after the user picks),
+see `propose_lessons_tool.py` and `generate_lesson_content_tool.py`.
+"""
 
 import json
 
@@ -6,6 +16,7 @@ from pydantic import BaseModel
 from agents import RunContextWrapper, function_tool
 from harness.context import AppContext
 from services.flashcard_service import create_flashcard_set
+from services.lesson_service import insert_ready_lesson
 from services.transcript_service import create_transcript_message
 from services.supabase_client import get_supabase_admin_client
 
@@ -24,11 +35,11 @@ async def generate_flashcards(
     cards: list[FlashcardInput],
 ) -> str:
     """
-    Generate a set of flashcards for a vocabulary collection.
-
-    Use this tool when the user wants to learn a collection of vocabulary words,
-    such as days of the week, colours, months, common foods, clothing, animals,
-    body parts, numbers, or any other thematic group of words.
+    Generate a set of flashcards for a vocabulary collection, bypassing the
+    proposal flow. Use this when the conversation makes it obvious the user
+    wants this exact deck right now (e.g. they explicitly ask for "days of
+    the week flashcards"). For browsing-style requests where the user might
+    want to choose between options, use `propose_lessons` instead.
 
     Each card must include:
     - arabic_text: The word in Arabic with FULL harakaat (diacritical marks)
@@ -68,6 +79,18 @@ async def generate_flashcards(
         language=language,
         cards=card_dicts,
         user_id=user_id,
+    )
+
+    # Record a `lessons` row so this deck shows up in the user's lessons history.
+    insert_ready_lesson(
+        user_id=user_id,
+        session_id=session_id,
+        title=topic,
+        blurb=f"{len(cards)}-card flashcard set on {topic}.",
+        fmt="flashcards",
+        content_table="flashcard_sets",
+        content_id=set_id,
+        generation_hints={"cards": card_dicts},
     )
 
     # Create a transcript message so the frontend can render the flashcard deck

--- a/web-api/agent/tutor/tools/generate_lesson_content_tool.py
+++ b/web-api/agent/tutor/tools/generate_lesson_content_tool.py
@@ -1,0 +1,124 @@
+"""Tool: generate_lesson_content — generate the content for a picked lesson.
+
+Drives the lesson state machine for the chosen tile:
+
+    proposed -> generating -> ready  (siblings -> dismissed)
+
+Dispatches generation by reading the format's `generator_handler` from
+`lesson_formats` and calling it. The handler creates the format-specific
+content rows (e.g. a `flashcard_sets` + `flashcards`) and returns the link.
+This tool then populates the lesson's polymorphic `content_table` /
+`content_id` and emits the format-appropriate transcript message so the
+frontend renders the new content (e.g. a flashcard deck bubble).
+"""
+
+import json
+import traceback
+
+from agents import RunContextWrapper, function_tool
+
+from harness.context import AppContext
+from services.lesson_service import (
+    dismiss_sibling_proposals,
+    get_lesson,
+    get_lesson_format,
+    resolve_generator,
+    update_lesson,
+)
+from services.supabase_client import get_supabase_admin_client
+from services.transcript_service import create_transcript_message
+
+
+@function_tool
+async def generate_lesson_content(
+    context: RunContextWrapper[AppContext],
+    lesson_id: str,
+) -> str:
+    """
+    Generate the actual content for a previously-proposed lesson and present it
+    to the user. Call this only after `propose_lessons` has been called and the
+    user has picked one of the tiles. Pass the lesson_id of the picked tile,
+    which was returned from `propose_lessons`.
+
+    This tool dismisses the sibling proposals, generates the format-specific
+    content (e.g. flashcards), and emits the rendered content into the chat.
+
+    Args:
+        lesson_id: The UUID of the lesson the user picked.
+
+    Returns:
+        Confirmation string. After this returns, do not produce any further
+        commentary — let the rendered lesson speak for itself.
+    """
+    app_context = context.context
+    session_id = app_context.session_id
+
+    user_id = app_context.user.user_id
+    if not user_id:
+        supabase = get_supabase_admin_client()
+        session_response = (
+            supabase.table("agent_sessions")
+            .select("user_id")
+            .eq("session_id", session_id)
+            .execute()
+        )
+        if session_response.data:
+            user_id = session_response.data[0]["user_id"]
+    if not user_id:
+        return "Could not generate the lesson — unable to identify the user."
+
+    lesson = get_lesson(lesson_id)
+    if not lesson:
+        return f"No lesson found with id {lesson_id}."
+    if lesson["created_by"] != user_id:
+        return "That lesson does not belong to the current user."
+    if lesson["status"] != "proposed":
+        return (
+            f"Lesson {lesson_id} is in status '{lesson['status']}', not 'proposed'. "
+            "It can't be generated again."
+        )
+
+    fmt = get_lesson_format(lesson["format"])
+    if not fmt or not fmt.get("enabled"):
+        return f"Lesson format '{lesson['format']}' is not available."
+
+    update_lesson(lesson_id, status="generating", error=None)
+    dismiss_sibling_proposals(
+        proposal_group_id=lesson["proposal_group_id"],
+        except_id=lesson_id,
+    )
+
+    try:
+        handler = resolve_generator(fmt["generator_handler"])
+        content_table, content_id = await handler(app_context, lesson)
+    except Exception as exc:
+        traceback.print_exc()
+        update_lesson(lesson_id, status="failed", error=str(exc))
+        return f"Sorry, generating that lesson failed: {exc}"
+
+    update_lesson(
+        lesson_id,
+        status="ready",
+        content_table=content_table,
+        content_id=content_id,
+    )
+
+    if lesson["format"] == "flashcards":
+        await create_transcript_message(
+            session_id=session_id,
+            message_source="tutor",
+            message_kind="flash_cards",
+            message_text=json.dumps({"set_id": content_id, "title": lesson["title"]}),
+            flow="tutor",
+        )
+    else:
+        # Future formats: extend this dispatch as new renderers land.
+        return (
+            f"Generated lesson '{lesson['title']}' but no transcript renderer "
+            f"is wired up for format '{lesson['format']}' yet."
+        )
+
+    return (
+        f"Lesson '{lesson['title']}' is ready and has been shown to the user. "
+        "Do not produce additional commentary."
+    )

--- a/web-api/agent/tutor/tools/generators/flashcards.py
+++ b/web-api/agent/tutor/tools/generators/flashcards.py
@@ -1,0 +1,45 @@
+"""Generator handler for the 'flashcards' lesson format.
+
+Dispatched by `generate_lesson_content` after a user picks a flashcard-format
+proposal. Reads the cards out of the lesson's `generation_hints` JSONB and
+delegates to the existing `create_flashcard_set` service.
+
+The hints payload is expected to look like:
+    {
+        "cards": [
+            {"arabic_text": "...", "transliteration": "...", "english": "..."},
+            ...
+        ]
+    }
+"""
+
+from typing import Any
+
+from harness.context import AppContext
+from services.flashcard_service import create_flashcard_set
+
+
+CONTENT_TABLE = "flashcard_sets"
+
+
+async def generate(app_context: AppContext, lesson: dict[str, Any]) -> tuple[str, str]:
+    """Generate a flashcard set for the given lesson row.
+
+    Returns (content_table, content_id) so the caller can populate the lesson's
+    polymorphic content link.
+    """
+    hints = lesson.get("generation_hints") or {}
+    cards = hints.get("cards") or []
+    if not cards:
+        raise ValueError(
+            "flashcards generator requires generation_hints.cards to be a non-empty list"
+        )
+
+    set_id = await create_flashcard_set(
+        title=lesson["title"],
+        language=app_context.agent.language,
+        cards=cards,
+        user_id=lesson["created_by"],
+    )
+
+    return (CONTENT_TABLE, set_id)

--- a/web-api/agent/tutor/tools/propose_lessons_tool.py
+++ b/web-api/agent/tutor/tools/propose_lessons_tool.py
@@ -1,0 +1,157 @@
+"""Tool: propose_lessons — offer the user a few lesson ideas to pick from.
+
+Inserts one `lessons` row per proposal in `status='proposed'`, all sharing a
+`proposal_group_id`. Then emits a `message_kind='component'` transcript message
+pointing at that group; the frontend's LessonProposalTiles component subscribes
+to the group via realtime and renders the tiles.
+
+Crucially, this tool does NOT generate any lesson content — content is only
+generated when the user picks a tile and the tutor follows up with
+`generate_lesson_content(lesson_id)`. That keeps generation cost proportional
+to lessons actually used.
+"""
+
+import json
+import uuid
+from typing import Literal, Optional
+
+from agents import RunContextWrapper, function_tool
+from pydantic import BaseModel, Field
+
+from harness.context import AppContext
+from services.lesson_service import insert_lesson_proposals
+from services.supabase_client import get_supabase_admin_client
+from services.transcript_service import create_transcript_message
+
+
+class FlashcardCardHint(BaseModel):
+    """A single flashcard the agent has decided to include if this proposal is picked."""
+    arabic_text: str
+    transliteration: str
+    english: str
+
+
+class LessonProposal(BaseModel):
+    """One proposed lesson the user could pick."""
+    title: str = Field(..., description="Short, evocative title shown on the tile (e.g. 'Days of the Week').")
+    blurb: str = Field(..., description="One-sentence description of what the lesson covers and why it's a good fit.")
+    arabic_preview: Optional[str] = Field(
+        None,
+        description="Optional short Arabic word/phrase shown on the tile (with harakaat).",
+    )
+    format: Literal["flashcards"] = Field(
+        ...,
+        description="Lesson format. Only 'flashcards' is supported in v1.",
+    )
+    cards: Optional[list[FlashcardCardHint]] = Field(
+        None,
+        description=(
+            "For format='flashcards', the list of cards to generate IF the user picks "
+            "this tile. Required for flashcards. Each card must have arabic_text "
+            "with full harakaat, a Latin transliteration, and an English translation."
+        ),
+    )
+
+
+@function_tool
+async def propose_lessons(
+    context: RunContextWrapper[AppContext],
+    intro: str,
+    proposals: list[LessonProposal],
+) -> str:
+    """
+    Offer the user 2-4 lesson ideas to pick from. Use this when the user asks
+    for a lesson, expresses an interest you can build a lesson around, or you
+    want to suggest practice options. The user picks one tile and the tutor
+    follows up with `generate_lesson_content` for the chosen lesson.
+
+    Do NOT call this and `generate_lesson_content` in the same turn. Wait for
+    the user to pick. Do NOT propose lessons whose content you cannot fully
+    specify upfront in the per-format hint fields (e.g. for flashcards, the
+    full card list must be provided here).
+
+    Args:
+        intro: One short conversational line introducing the picker (currently
+            persisted but not displayed; useful for analytics).
+        proposals: 2 to 4 lesson proposals. Each must include a title, blurb,
+            and the per-format generation hints needed to actually generate
+            the content if picked (e.g. `cards` for flashcards).
+
+    Returns:
+        A confirmation string listing the proposed lessons and their IDs. Keep
+        these IDs in mind — when the user picks one, you'll pass the matching
+        ID to `generate_lesson_content`.
+    """
+    app_context = context.context
+    session_id = app_context.session_id
+
+    if not (2 <= len(proposals) <= 4):
+        return f"Expected 2-4 proposals; got {len(proposals)}."
+
+    user_id = app_context.user.user_id
+    if not user_id:
+        supabase = get_supabase_admin_client()
+        session_response = (
+            supabase.table("agent_sessions")
+            .select("user_id")
+            .eq("session_id", session_id)
+            .execute()
+        )
+        if session_response.data:
+            user_id = session_response.data[0]["user_id"]
+    if not user_id:
+        return "Could not propose lessons — unable to identify the user."
+
+    # Pack format-specific fields into generation_hints so the generator can
+    # read them later without us having to extend the lessons schema.
+    rows_to_insert = []
+    for p in proposals:
+        hints: dict = {}
+        if p.format == "flashcards":
+            if not p.cards:
+                return (
+                    f"Proposal '{p.title}' is format='flashcards' but has no cards. "
+                    "Provide the full card list when proposing a flashcard lesson."
+                )
+            hints["cards"] = [c.model_dump() for c in p.cards]
+
+        rows_to_insert.append(
+            {
+                "title": p.title,
+                "blurb": p.blurb,
+                "arabic_preview": p.arabic_preview,
+                "format": p.format,
+                "generation_hints": hints,
+            }
+        )
+
+    proposal_group_id = str(uuid.uuid4())
+    inserted = insert_lesson_proposals(
+        proposal_group_id=proposal_group_id,
+        user_id=user_id,
+        session_id=session_id,
+        proposals=rows_to_insert,
+    )
+
+    await create_transcript_message(
+        session_id=session_id,
+        message_source="tutor",
+        message_kind="component",
+        message_text=json.dumps(
+            {
+                "component_name": "LessonProposalTiles",
+                "props": {
+                    "proposal_group_id": proposal_group_id,
+                    "intro": intro,
+                },
+            }
+        ),
+        flow="tutor",
+    )
+
+    summary = ", ".join(f"'{row['title']}' (id: {row['id']})" for row in inserted)
+    return (
+        f"Proposed {len(inserted)} lessons: {summary}. "
+        "Wait for the user to pick a tile. When they do, call "
+        "`generate_lesson_content` with the matching lesson id."
+    )

--- a/web-api/agent/tutor/tutor_agent.py
+++ b/web-api/agent/tutor/tutor_agent.py
@@ -6,6 +6,8 @@ from harness.options import HarnessOptions
 
 from .tools.change_language_tool import change_language
 from .tools.flashcards_tool import generate_flashcards
+from .tools.generate_lesson_content_tool import generate_lesson_content
+from .tools.propose_lessons_tool import propose_lessons
 from .tools.send_audio_tool import send_audio
 from .tutor_agent_hooks import TutorAgentHooks
 from .tutor_instructions import get_instructions
@@ -16,6 +18,8 @@ agent = Agent(
     tools=[
         change_language,
         generate_flashcards,
+        propose_lessons,
+        generate_lesson_content,
         send_audio,
     ],
     hooks=TutorAgentHooks(),

--- a/web-api/services/lesson_service.py
+++ b/web-api/services/lesson_service.py
@@ -1,0 +1,123 @@
+"""Service for managing lesson rows and their format-specific content."""
+
+import importlib
+import uuid
+from typing import Any, Optional
+
+from .supabase_client import get_supabase_admin_client
+
+
+def insert_lesson_proposals(
+    proposal_group_id: str,
+    user_id: str,
+    session_id: Optional[str],
+    proposals: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Insert N rows in `status='proposed'` sharing the same proposal_group_id.
+
+    Each `proposals` entry must include `title`, `blurb`, and `format`, and may
+    include `arabic_preview` and `generation_hints`.
+    """
+    rows = [
+        {
+            "proposal_group_id": proposal_group_id,
+            "created_by": user_id,
+            "session_id": session_id,
+            "title": p["title"],
+            "blurb": p["blurb"],
+            "arabic_preview": p.get("arabic_preview"),
+            "format": p["format"],
+            "generation_hints": p.get("generation_hints") or {},
+            "status": "proposed",
+        }
+        for p in proposals
+    ]
+    result = get_supabase_admin_client().table("lessons").insert(rows).execute()
+    return result.data or []
+
+
+def insert_ready_lesson(
+    user_id: str,
+    session_id: Optional[str],
+    title: str,
+    blurb: str,
+    fmt: str,
+    content_table: str,
+    content_id: str,
+    arabic_preview: Optional[str] = None,
+    generation_hints: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Insert a `status='ready'` row with content already linked.
+
+    Used by the direct-path flashcards tool, which generates content first and
+    only then records the lesson — there's no proposal cycle to go through.
+    Each direct lesson is a singleton proposal group of size 1.
+    """
+    row = {
+        "proposal_group_id": str(uuid.uuid4()),
+        "created_by": user_id,
+        "session_id": session_id,
+        "title": title,
+        "blurb": blurb,
+        "arabic_preview": arabic_preview,
+        "format": fmt,
+        "generation_hints": generation_hints or {},
+        "content_table": content_table,
+        "content_id": content_id,
+        "status": "ready",
+    }
+    result = get_supabase_admin_client().table("lessons").insert(row).execute()
+    return result.data[0]
+
+
+def get_lesson(lesson_id: str) -> Optional[dict[str, Any]]:
+    result = (
+        get_supabase_admin_client()
+        .table("lessons")
+        .select("*")
+        .eq("id", lesson_id)
+        .maybe_single()
+        .execute()
+    )
+    return result.data
+
+
+def get_lesson_format(slug: str) -> Optional[dict[str, Any]]:
+    result = (
+        get_supabase_admin_client()
+        .table("lesson_formats")
+        .select("*")
+        .eq("slug", slug)
+        .maybe_single()
+        .execute()
+    )
+    return result.data
+
+
+def update_lesson(lesson_id: str, **fields: Any) -> None:
+    if not fields:
+        return
+    get_supabase_admin_client().table("lessons").update(fields).eq("id", lesson_id).execute()
+
+
+def dismiss_sibling_proposals(proposal_group_id: str, except_id: str) -> None:
+    """Mark every still-`proposed` row in the group as `dismissed`, except the chosen one."""
+    (
+        get_supabase_admin_client()
+        .table("lessons")
+        .update({"status": "dismissed"})
+        .eq("proposal_group_id", proposal_group_id)
+        .eq("status", "proposed")
+        .neq("id", except_id)
+        .execute()
+    )
+
+
+def resolve_generator(handler_path: str):
+    """Resolve a dotted path like 'agent.tutor.tools.generators.flashcards.generate'
+    to the callable, importing the module if necessary."""
+    module_path, _, attr = handler_path.rpartition(".")
+    if not module_path or not attr:
+        raise ValueError(f"Invalid generator handler path: {handler_path!r}")
+    module = importlib.import_module(module_path)
+    return getattr(module, attr)

--- a/web-app/src/components/ChatView/ChatView.tsx
+++ b/web-app/src/components/ChatView/ChatView.tsx
@@ -21,8 +21,15 @@ export function ChatView({ messages, onStartCall }: ChatViewProps) {
 
   // Memoize filtered messages so Transcript doesn't re-render on every keystroke
   const chatMessages = useMemo(
-    () => messages.filter((m) => m.message_kind === 'text' || m.message_kind === 'audio' || m.message_kind === 'flash_cards'),
-    [messages]
+    () =>
+      messages.filter(
+        (m) =>
+          m.message_kind === 'text' ||
+          m.message_kind === 'audio' ||
+          m.message_kind === 'flash_cards' ||
+          m.message_kind === 'component',
+      ),
+    [messages],
   );
 
   const handleSendMessage = (e: FormEvent) => {

--- a/web-app/src/components/Transcript/Transcript.tsx
+++ b/web-app/src/components/Transcript/Transcript.tsx
@@ -1,11 +1,13 @@
 import { motion, AnimatePresence } from 'motion/react';
-import { forwardRef, memo, useEffect, useRef, type HTMLAttributes } from 'react';
+import { forwardRef, memo, useCallback, useEffect, useRef, type HTMLAttributes } from 'react';
 import { Box, Flex, Text } from '@chakra-ui/react';
 import type { TranscriptMessage, ResponseMode } from '@/api/sessions/sessions.types';
 import { AudioBubble } from './AudioBubble';
 import { HighlightedText } from './HighlightedText';
 import { MarkdownContent } from './MarkdownContent';
 import { FlashcardDeck } from '@/components/FlashcardDeck';
+import { renderTranscriptComponent } from '@/components/TranscriptComponents/registry';
+import type { LessonRow } from '@/hooks/useLessonProposalGroup';
 import { useStore } from '@/store';
 
 export type { TranscriptMessage };
@@ -43,6 +45,7 @@ function getDisplayText(message: TranscriptMessage, mode: ResponseMode): string 
 function TranscriptBubble({ message, isFirstInGroup, responseMode }: TranscriptBubbleProps) {
   const isUser = message.message_source === 'user';
   const isTutor = message.message_source === 'tutor';
+  const sendMessage = useStore((s) => s.session.sendMessage);
 
   // Flashcard messages render as a full-width deck, not inside a bubble
   if (message.message_kind === 'flash_cards') {
@@ -56,6 +59,12 @@ function TranscriptBubble({ message, isFirstInGroup, responseMode }: TranscriptB
       >
         <FlashcardDeck message={message} />
       </MotionBox>
+    );
+  }
+
+  if (message.message_kind === 'component') {
+    return (
+      <ComponentBubble message={message} sendMessage={sendMessage} />
     );
   }
 
@@ -110,6 +119,42 @@ function TranscriptBubble({ message, isFirstInGroup, responseMode }: TranscriptB
           <MarkdownContent>{displayText}</MarkdownContent>
         )}
       </Box>
+    </MotionBox>
+  );
+}
+
+function ComponentBubble({
+  message,
+  sendMessage,
+}: {
+  message: TranscriptMessage;
+  sendMessage: (m: string) => Promise<void>;
+}) {
+  const handlePickProposal = useCallback(
+    (lesson: LessonRow) => {
+      // The lesson_id was returned to the agent as part of the propose_lessons
+      // tool result, so the LLM already has it in context — we just send a
+      // natural-language pick and let the agent map title to id.
+      void sendMessage(`Let's do the "${lesson.title}" lesson.`);
+    },
+    [sendMessage],
+  );
+
+  const rendered = renderTranscriptComponent(message, {
+    LessonProposalTiles: { onPick: handlePickProposal },
+  });
+
+  if (!rendered) return null;
+
+  return (
+    <MotionBox
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.3, ease: 'easeOut' }}
+      w="full"
+    >
+      {rendered}
     </MotionBox>
   );
 }

--- a/web-app/src/components/TranscriptComponents/LessonProposalTiles.tsx
+++ b/web-app/src/components/TranscriptComponents/LessonProposalTiles.tsx
@@ -1,0 +1,173 @@
+/**
+ * Realtime-driven tile picker for a lesson proposal group.
+ *
+ * Unlike the onboarding `LessonTiles` (which is props-driven and level-based),
+ * this component subscribes to a `proposal_group_id` and renders one tile per
+ * `lessons` row in the group. As the chosen tile transitions through
+ * `proposed -> generating -> ready`, the rendering reflects the live state.
+ */
+
+import { useMemo } from 'react';
+import {
+  useLessonProposalGroup,
+  type LessonRow,
+} from '@/hooks/useLessonProposalGroup';
+
+export type LessonProposalTilesProps = {
+  proposal_group_id: string;
+  intro?: string;
+};
+
+export type LessonProposalTilesContext = {
+  onPick: (lesson: LessonRow) => void;
+};
+
+export function LessonProposalTiles({
+  props,
+  ctx: { onPick },
+}: {
+  props: LessonProposalTilesProps;
+  ctx: LessonProposalTilesContext;
+}) {
+  const { lessons, loading, error } = useLessonProposalGroup(
+    props.proposal_group_id,
+  );
+
+  // Show only the proposals + the chosen one (whatever its status). Hide
+  // dismissed siblings — they make the row jitter when it collapses.
+  const visibleTiles = useMemo(
+    () =>
+      lessons.filter(
+        (l) => l.status !== 'dismissed' && l.status !== 'archived',
+      ),
+    [lessons],
+  );
+
+  const isAnyGenerating = visibleTiles.some(
+    (l) => l.status === 'generating',
+  );
+
+  if (loading || (visibleTiles.length === 0 && !error)) return null;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 12,
+        maxWidth: 680,
+        marginInline: 'auto',
+        padding: '0 16px',
+      }}
+    >
+      {error && (
+        <div style={{ color: '#fca5a5', fontSize: 13 }}>
+          Couldn't load lesson tiles: {error}
+        </div>
+      )}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(auto-fit, minmax(220px, 1fr))`,
+          gap: 12,
+        }}
+      >
+        {visibleTiles.map((lesson) => {
+          const isPicked =
+            lesson.status === 'generating' ||
+            lesson.status === 'ready' ||
+            lesson.status === 'in_progress' ||
+            lesson.status === 'completed';
+          const isFailed = lesson.status === 'failed';
+          const dimmed = isAnyGenerating && !isPicked;
+          const disabled = dimmed || isPicked || isFailed;
+
+          return (
+            <button
+              key={lesson.id}
+              onClick={() => !disabled && onPick(lesson)}
+              disabled={disabled}
+              style={{
+                textAlign: 'left',
+                padding: '16px 18px',
+                background: 'rgba(255, 255, 255, 0.06)',
+                border: `1px solid ${isPicked ? 'rgba(255,255,255,0.4)' : 'rgba(255, 255, 255, 0.15)'}`,
+                borderRadius: 16,
+                cursor: disabled ? 'default' : 'pointer',
+                fontFamily: 'inherit',
+                color: 'white',
+                opacity: dimmed ? 0.4 : 1,
+                transition:
+                  'opacity 200ms, border-color 200ms, transform 200ms',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 8,
+              }}
+              onMouseEnter={(e) => {
+                if (!disabled) {
+                  e.currentTarget.style.borderColor =
+                    'rgba(255,255,255,0.45)';
+                  e.currentTarget.style.transform = 'translateY(-2px)';
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (!disabled) {
+                  e.currentTarget.style.borderColor =
+                    'rgba(255,255,255,0.15)';
+                  e.currentTarget.style.transform = 'translateY(0)';
+                }
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  gap: 8,
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: 16,
+                    fontWeight: 700,
+                    letterSpacing: '-0.01em',
+                  }}
+                >
+                  {lesson.title}
+                </div>
+                {lesson.arabic_preview && (
+                  <div
+                    style={{
+                      fontFamily: 'Noto Sans Arabic, serif',
+                      direction: 'rtl',
+                      fontSize: 16,
+                      opacity: 0.85,
+                    }}
+                  >
+                    {lesson.arabic_preview}
+                  </div>
+                )}
+              </div>
+              <div style={{ fontSize: 13, opacity: 0.75, lineHeight: 1.4 }}>
+                {lesson.blurb}
+              </div>
+              {lesson.status === 'generating' && (
+                <div style={{ fontSize: 11, opacity: 0.7 }}>Preparing…</div>
+              )}
+              {lesson.status === 'ready' ||
+              lesson.status === 'in_progress' ||
+              lesson.status === 'completed' ? (
+                <div style={{ fontSize: 11, opacity: 0.7 }}>Ready</div>
+              ) : null}
+              {isFailed && (
+                <div style={{ fontSize: 11, color: '#fca5a5' }}>
+                  Couldn't prepare this one.
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web-app/src/components/TranscriptComponents/registry.tsx
+++ b/web-app/src/components/TranscriptComponents/registry.tsx
@@ -16,6 +16,11 @@ import {
   type LessonTilesContext,
   type LessonTilesProps,
 } from './LessonTiles';
+import {
+  LessonProposalTiles,
+  type LessonProposalTilesContext,
+  type LessonProposalTilesProps,
+} from './LessonProposalTiles';
 
 export type ComponentMessagePayload = {
   component_name: string;
@@ -39,21 +44,31 @@ export function parseComponentMessage(
 /** Context shapes indexed by component_name. Extend as new components land. */
 export type ComponentContextMap = {
   LessonTiles: LessonTilesContext;
+  LessonProposalTiles: LessonProposalTilesContext;
 };
 
 export function renderTranscriptComponent<K extends keyof ComponentContextMap>(
   message: TranscriptMessage,
-  ctxMap: ComponentContextMap,
+  ctxMap: Partial<ComponentContextMap>,
 ): ReactElement | null {
   const payload = parseComponentMessage(message);
   if (!payload) return null;
 
   switch (payload.component_name as K) {
     case 'LessonTiles':
+      if (!ctxMap.LessonTiles) return null;
       return (
         <LessonTiles
           props={payload.props as LessonTilesProps}
           ctx={ctxMap.LessonTiles}
+        />
+      );
+    case 'LessonProposalTiles':
+      if (!ctxMap.LessonProposalTiles) return null;
+      return (
+        <LessonProposalTiles
+          props={payload.props as LessonProposalTilesProps}
+          ctx={ctxMap.LessonProposalTiles}
         />
       );
     default:

--- a/web-app/src/hooks/useLessonProposalGroup.ts
+++ b/web-app/src/hooks/useLessonProposalGroup.ts
@@ -1,0 +1,120 @@
+/**
+ * Hook for subscribing to a lesson proposal group via Supabase Realtime.
+ *
+ * Fetches all `lessons` rows in the given proposal group and watches for
+ * INSERT/UPDATE events on the group so the tile picker can reflect the
+ * proposed -> generating -> ready transition without a page refresh.
+ */
+
+import { useEffect, useState } from 'react';
+import { useSupabase } from '@/context/SupabaseContext';
+
+export type LessonStatus =
+  | 'proposed'
+  | 'dismissed'
+  | 'generating'
+  | 'ready'
+  | 'in_progress'
+  | 'completed'
+  | 'failed'
+  | 'archived';
+
+export interface LessonRow {
+  id: string;
+  proposal_group_id: string;
+  created_by: string;
+  session_id: string | null;
+  title: string;
+  blurb: string;
+  arabic_preview: string | null;
+  format: string;
+  generation_hints: Record<string, unknown>;
+  content_table: string | null;
+  content_id: string | null;
+  status: LessonStatus;
+  error: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface UseLessonProposalGroupResult {
+  lessons: LessonRow[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function useLessonProposalGroup(
+  proposalGroupId: string | undefined,
+): UseLessonProposalGroupResult {
+  const supabase = useSupabase();
+  const [lessons, setLessons] = useState<LessonRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!proposalGroupId) {
+      setLessons([]);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchInitial = async () => {
+      setLoading(true);
+      const { data, error: fetchError } = await supabase
+        .from('lessons')
+        .select('*')
+        .eq('proposal_group_id', proposalGroupId)
+        .order('created_at', { ascending: true });
+
+      if (cancelled) return;
+      if (fetchError) {
+        setError(fetchError.message);
+        setLoading(false);
+        return;
+      }
+      setLessons((data ?? []) as LessonRow[]);
+      setLoading(false);
+    };
+
+    fetchInitial();
+
+    const channel = supabase
+      .channel(`lessons:group:${proposalGroupId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'lessons',
+          filter: `proposal_group_id=eq.${proposalGroupId}`,
+        },
+        (payload) => {
+          if (cancelled) return;
+          if (payload.eventType === 'INSERT') {
+            const row = payload.new as LessonRow;
+            setLessons((prev) =>
+              prev.some((l) => l.id === row.id) ? prev : [...prev, row],
+            );
+          } else if (payload.eventType === 'UPDATE') {
+            const row = payload.new as LessonRow;
+            setLessons((prev) => prev.map((l) => (l.id === row.id ? row : l)));
+          } else if (payload.eventType === 'DELETE') {
+            const row = payload.old as { id: string };
+            setLessons((prev) => prev.filter((l) => l.id !== row.id));
+          }
+        },
+      )
+      .subscribe();
+
+    return () => {
+      cancelled = true;
+      supabase.removeChannel(channel);
+    };
+  }, [supabase, proposalGroupId]);
+
+  return { lessons, loading, error };
+}


### PR DESCRIPTION
## Summary

Introduces a unified \`lessons\` data type so the tutor can offer a few lesson options, let the user pick, and only then generate the actual content — keeping generation cost proportional to lessons actually used.

- **\`lessons\` umbrella table** + lookup \`lesson_formats\` (seeded with \`flashcards\`). Polymorphic content link via \`(content_table, content_id)\` so new formats slot in without schema churn. RLS scoped to creator; realtime enabled so tile state can stream live.
- **Two new tutor tools**: \`propose_lessons\` inserts N tiles in \`status='proposed'\` sharing a \`proposal_group_id\` and emits a \`message_kind='component'\` transcript message; \`generate_lesson_content(lesson_id)\` dispatches via \`lesson_formats.generator_handler\`, runs the format-specific generator (currently flashcards), updates the polymorphic link, and emits the rendered content.
- **Direct-path \`generate_flashcards\` is preserved** for unsolicited mid-conversation decks; it now also records a \`status='ready'\` lessons row so \`lessons\` is the single source of truth for what the user has.
- **Frontend**: new \`useLessonProposalGroup\` realtime hook + \`LessonProposalTiles\` component driven by \`proposal_group_id\`. Tile state (\`proposed → generating → ready\`, siblings → \`dismissed\`) streams live without a refetch. Onboarding's existing \`LessonTiles\` is untouched; the registry's \`ctxMap\` is now \`Partial<>\` so each surface only supplies the contexts it uses.

## Why two steps?

A single \`generate\` tool would force the LLM to commit to one lesson before the user has expressed a preference. Splitting proposal from generation lets the agent offer 2–4 options on a single turn and only spend image/audio generation budget on the one the user actually picks.

## Tutor instruction update

\`tutor/languages/ar-AR.md\` now distinguishes:
- explicit deck request → \`generate_flashcards\` (direct)
- broader interest → \`propose_lessons\` then wait
- user picks a tile → \`generate_lesson_content\` with the matching id (the LLM keeps the tile→id map from \`propose_lessons\`'s tool result)

Other language files were left for follow-up.

## Test plan

- [x] Migration applies cleanly (\`supabase migration up\`); table inspected with \`\d public.lessons\`
- [x] \`lesson_formats\` seeded row visible (\`flashcards → flashcard_sets → agent.tutor.tools.generators.flashcards.generate\`)
- [x] Tutor agent imports cleanly with 5 tools registered
- [x] Existing pytest suite passes (19/19 non-pre-existing tests; the 2 \`test_content_service.py\` failures pre-date this branch)
- [x] \`tsc --noEmit\` clean
- [x] Browser smoke test: injected a proposal group + component message into the DB; tiles rendered live in the chat view
- [x] State transitions \`proposed → generating → ready\` stream via realtime; dismissed siblings disappear
- [x] Click handler sends \`Let's do the "{title}" lesson.\` user message
- [ ] End-to-end through the agent (run web-api from this branch, ask "I want to talk about food in Cairo", pick a tile, watch the deck appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)