### PR TITLE
feat(onboarding): redirect placeholder when lessons are proposed

### DIFF
--- a/web-app/src/pages/Landing.tsx
+++ b/web-app/src/pages/Landing.tsx
@@ -110,9 +110,9 @@ function FadeSlide({ show, children, delay = 0 }: { show: boolean; children: Rea
   );
 }
 
-export function UserInput({ theme, isMobile, prefilled = null, autoFocus = true, onSubmit, onMicClick, disabled = false }: {
+export function UserInput({ theme, isMobile, prefilled = null, autoFocus = true, onSubmit, onMicClick, disabled = false, placeholder }: {
   theme: Theme; isMobile: boolean; prefilled?: string | null; autoFocus?: boolean;
-  onSubmit: (msg: string) => void; onMicClick?: () => void; disabled?: boolean;
+  onSubmit: (msg: string) => void; onMicClick?: () => void; disabled?: boolean; placeholder?: string;
 }) {
   const [value, setValue] = useState(prefilled || '');
   const inputRef = useRef<HTMLInputElement>(null);
@@ -159,7 +159,7 @@ export function UserInput({ theme, isMobile, prefilled = null, autoFocus = true,
         boxShadow: `0 20px 40px -24px ${theme.tint}66, 0 0 0 4px ${theme.tintSoft}`,
       }}
     >
-      <style>{`@keyframes mmInputShine { 0% { transform: translateX(-100%); } 100% { transform: translateX(200%); } }`}</style>
+      <style>{`@keyframes mmInputShine { 0% { transform: translateX(-100%); } 100% { transform: translateX(200%); } } .mm-userinput::placeholder { color: ${theme.tint}80; -webkit-text-fill-color: ${theme.tint}80; opacity: 1; } .mm-userinput::-webkit-input-placeholder { color: ${theme.tint}80; -webkit-text-fill-color: ${theme.tint}80; opacity: 1; }`}</style>
       {disabled && (
         <span
           aria-hidden="true"
@@ -176,9 +176,11 @@ export function UserInput({ theme, isMobile, prefilled = null, autoFocus = true,
       <input
         ref={inputRef}
         type="text"
+        className="mm-userinput"
         value={value}
         onChange={(e) => setValue(e.target.value)}
         disabled={disabled}
+        placeholder={placeholder}
         autoComplete="off"
         style={{
           flex: 1, minWidth: 0,

--- a/web-app/src/pages/Onboarding.tsx
+++ b/web-app/src/pages/Onboarding.tsx
@@ -586,6 +586,7 @@ export function Onboarding({ color = 'apricot' }: OnboardingProps) {
               onSubmit={handleSubmit}
               onMicClick={handleMicClick}
               disabled={submitPending}
+              placeholder={componentMessages.length > 0 ? "actually, i'd like to learn about..." : undefined}
             />
           </div>
         </section>


### PR DESCRIPTION
## Summary

- At the end of onboarding, when the agent's `generate_lessons` tool produces the `LessonTiles` component message, the text input now shows the placeholder `actually, i'd like to learn about...` so the redirect affordance is discoverable.
- Placeholder is only set on this final view (gated on `componentMessages.length > 0`); earlier onboarding turns keep an empty input.
- Placeholder text renders in the theme tint at 50% alpha (also overriding `-webkit-text-fill-color`, which was inheriting `theme.ink` and rendering placeholder text near-black) so it reads as a hint, not as user-typed content.

## Files

- [web-app/src/pages/Landing.tsx](web-app/src/pages/Landing.tsx) — `UserInput` accepts an optional `placeholder` prop, the input gets a `mm-userinput` class, and the inline `<style>` block adds `::placeholder` rules for color and `-webkit-text-fill-color`.
- [web-app/src/pages/Onboarding.tsx](web-app/src/pages/Onboarding.tsx) — passes the placeholder string only when component messages (currently only `LessonTiles`) are present.

## Test plan

- [ ] Walk through onboarding to the lessons-proposed view; confirm placeholder appears in semitransparent orange.
- [ ] On earlier onboarding turns (e.g. "what is your name?"), confirm input has no placeholder.
- [ ] Confirm typing into the input causes the placeholder to disappear and submitted text renders in the normal dark color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)