### PR TITLE
refactor(onboarding): harness owns transcript persistence, tools just queue UI

### DIFF
--- a/web-api/agent/onboarding/onboarding_agent.py
+++ b/web-api/agent/onboarding/onboarding_agent.py
@@ -1,18 +1,24 @@
 """Onboarding agent — single goal-driven agent.
 
-Replaces the earlier per-step state machine. The agent decides cadence: it
-greets the learner, gathers what it needs (name, motivation), respects
-refusals, and once it has enough calls `generate_lessons` to render the
-starter tiles and mark onboarding complete.
+The agent decides cadence: it greets the learner, gathers what it needs
+(name, motivation), respects refusals, and once it has enough calls
+`generate_lessons` to finish onboarding and queue the lesson tiles.
 
-Visible chat bubbles come from the agent's `final_output`. The harness
-persists each turn to `transcript_messages` (one row per turn); the UI
-splits sentence boundaries client-side so a multi-sentence reply still
-renders as multiple bubbles. The `generate_lessons` tool emits its own
-`message_kind="component"` row for the lesson tiles.
+Visible chat bubbles are the agent's plain assistant text. The harness
+walks `result.new_items` after each turn and persists every
+`MessageOutputItem` to `transcript_messages`; the UI splits sentence
+boundaries client-side so a multi-sentence reply still renders as
+multiple bubbles. The `generate_lessons` tool queues a `LessonTiles`
+ComponentMessage on the context outbox and the harness persists that
+as a `message_kind='component'` row in the same turn.
+
+The loop is left alone (no `StopAtTools`): when the agent calls
+`generate_lessons`, the tool's "ok" return goes back to the model and
+the model produces the handoff sentence as its post-tool reply. The
+prompt nails that to the duroos line so we don't get trailing chatter.
 """
 
-from agents import Agent, StopAtTools
+from agents import Agent
 
 from harness.options import HarnessOptions
 
@@ -24,17 +30,11 @@ agent = Agent(
     name="Onboarding",
     instructions=get_instructions,
     tools=[generate_lessons],
-    # generate_lessons is the closing moment — its component message carries
-    # the picker UI, so any agent text after it is just noise that would be
-    # persisted now that persist_final_output is on. Stop the agent loop
-    # there.
-    tool_use_behavior=StopAtTools(stop_at_tool_names=["generate_lessons"]),
 )
 
 
 harness_options = HarnessOptions(
     scaffold=False,
-    persist_final_output=True,
     flow_tag="onboarding",
     user_message_kind="text",
     idle_followups=False,

--- a/web-api/agent/onboarding/system.md
+++ b/web-api/agent/onboarding/system.md
@@ -5,10 +5,10 @@ Gather two pieces of information so we can recommend starter lessons:
 1. The learner's **name** (first name is enough).
 2. Their **motivation** — what is drawing them to Arabic? (travel, family heritage, religion, work, partner, idle curiosity, etc.)
 
-Once you have both (or have respectfully recorded a refusal as the value), reply with one short sentence handing off to the lesson picker — use the Arabic word **duroos** (lessons, plural of *dars*) in place of the English word, e.g. "why don't we start with one of these duroos?". Then call `generate_lessons` exactly once. The tiles are the closing moment — produce no further text after that call.
+Once you have both (or have respectfully recorded a refusal as the value), call `generate_lessons` exactly once with the three tiles. Do **not** write any chat text in the same response as that tool call — the tool returns `"ok"` and the conversation comes back to you for one final reply. That final reply is **only** the handoff sentence using the Arabic word **duroos** (lessons, plural of *dars*) in place of the English word, e.g. "why don't we start with one of these duroos?". One sentence, nothing else — no list of the tiles, no "all done", no "enjoy". The tiles render themselves. Don't worry about highlighting `duroos` — the harness tints flow vocab automatically.
 
 ## Tools
-- `generate_lessons(intro, tiles)` — render the three lesson tiles and complete onboarding. Call exactly once at the end. The agent must already have a `name` and a `motivation` (or accepted refusals) before calling.
+- `generate_lessons(tiles)` — finish onboarding and render the three lesson tiles. Call exactly once at the end, on its own (no chat text in the same response). The agent must already have a `name` and a `motivation` (or accepted refusals) before calling.
 
 ## Conversation rules
 - Reply in one short message — 1–2 short sentences. The UI splits on sentence boundaries (`.`, `?`, `!`) into separate bubbles, so write naturally with terminators; do not use newlines for layout.

--- a/web-api/agent/onboarding/tools/generate_lessons_tool.py
+++ b/web-api/agent/onboarding/tools/generate_lessons_tool.py
@@ -1,10 +1,12 @@
-"""Tool: generate_lessons — emit the lesson-tile UI and finish onboarding.
+"""Tool: generate_lessons — finalize onboarding and queue the lesson tiles.
 
-Persists a `message_kind='component'` transcript message whose `message_text`
-is the JSON payload `{"component_name": "LessonTiles", "props": {intro, tiles}}`.
-The frontend's TranscriptComponents registry renders this into the three-tile
-picker. Calling this tool also marks onboarding as `completed` and upserts
-the profile row from `app_context.onboarding.collected`.
+Marks `onboarding.completed`, upserts the user's profile row, and queues a
+`LessonTiles` ComponentMessage on `app_context.outbox`. The harness drains
+the outbox after the turn and persists it as a `message_kind='component'`
+transcript_messages row. The handoff text bubble (the agent's "why don't
+we start with one of these duroos?" line) is the agent's own assistant
+text, persisted by the harness from `result.new_items` — not anything
+this tool does.
 """
 
 import json
@@ -14,10 +16,10 @@ from typing import List, Literal, Optional
 from agents import RunContextWrapper, function_tool
 from pydantic import BaseModel
 
+from harness.components import ComponentMessage
 from harness.context import AppContext
 from harness.session_manager import get_session
 from services.supabase_client import get_supabase_admin_client
-from services.transcript_service import create_transcript_message
 
 
 def _log(msg: str) -> None:
@@ -68,22 +70,26 @@ class LessonTile(BaseModel):
 @function_tool
 async def generate_lessons(
     context: RunContextWrapper[AppContext],
-    intro: str,
     tiles: List[LessonTile],
 ) -> str:
     """
     Render three starter-lesson tiles tailored to the learner's motivation
-    and mark onboarding complete. Call this exactly once, after you have a
-    `name` and a `motivation` (or recorded the learner's refusal of either).
+    and finish onboarding. Call this exactly once, after you have a `name`
+    and a `motivation` (or recorded the learner's refusal of either).
+
+    In the SAME response as this tool call, write a short handoff sentence
+    (e.g. "why don't we start with one of these duroos?"). That text becomes
+    the on-screen bubble shown just above the tile picker — the harness
+    persists it automatically. The Arabic word `duroos` (lessons) is tinted
+    on screen via flow vocab; you don't need to mark it up.
 
     Args:
-        intro: One short line to introduce the picker. Currently not displayed
-            on screen but persisted for analytics; keep it warm and concrete.
         tiles: Exactly three tiles — one Beginner, one Intermediate, one
             Advanced — each tailored to the learner's stated motivation.
+            Each needs a `level`, a short `title` (3–6 words), a one-sentence
+            `blurb`, and optionally a single Arabic word/phrase (`arabic`).
     """
     app_context = context.context
-    session_id = app_context.session_id
 
     if app_context.onboarding.completed:
         return "Onboarding is already complete; do not call generate_lessons again."
@@ -98,19 +104,10 @@ async def generate_lessons(
             "(Beginner, Intermediate, Advanced)."
         )
 
-    props = {
-        "intro": intro,
-        "tiles": [t.model_dump() for t in tiles],
-    }
+    props = {"tiles": [t.model_dump() for t in tiles]}
 
-    await create_transcript_message(
-        session_id=session_id,
-        message_source="tutor",
-        message_kind="component",
-        message_text=json.dumps(
-            {"component_name": "LessonTiles", "props": props}
-        ),
-        flow="onboarding",
+    app_context.outbox.append(
+        ComponentMessage(component_name="LessonTiles", props=props)
     )
 
     app_context.onboarding.collected["suggestions"] = props
@@ -118,7 +115,4 @@ async def generate_lessons(
 
     _write_profile(app_context, props)
 
-    # Empty return: the agent uses StopAtTools, so this becomes final_output.
-    # The harness skips persisting empty output, so no extraneous text bubble
-    # appears alongside the tile picker.
-    return ""
+    return "ok"

--- a/web-api/agent/tutor/tutor_agent.py
+++ b/web-api/agent/tutor/tutor_agent.py
@@ -28,7 +28,6 @@ agent = Agent(
 
 harness_options = HarnessOptions(
     scaffold=True,
-    persist_final_output=True,
     flow_tag="tutor",
     idle_followups=True,
     user_none_system_prompt=(

--- a/web-api/channels/chat/turn_dispatcher.py
+++ b/web-api/channels/chat/turn_dispatcher.py
@@ -52,19 +52,20 @@ async def dispatch_turn(
 async def _send_transcript(
     session_id: str, result: TurnResult, config: TurnConfig
 ) -> None:
-    if result.persisted_message:
-        await send_message(
-            session_id,
-            Message(
-                kind="transcript",
-                data=result.persisted_message.model_dump(mode="json"),
-            ),
-        )
+    if result.persisted_messages:
+        for msg in result.persisted_messages:
+            await send_message(
+                session_id,
+                Message(
+                    kind="transcript",
+                    data=msg.model_dump(mode="json"),
+                ),
+            )
         return
 
-    # Persist failed (or was disabled) but we still have visible text —
+    # Persistence produced nothing but we still have visible text —
     # send a degraded payload so the user isn't stuck waiting.
-    if config.persist_final_output and result.display_text.strip():
+    if result.display_text.strip():
         await send_message(
             session_id,
             Message(

--- a/web-api/harness/components.py
+++ b/web-api/harness/components.py
@@ -1,0 +1,22 @@
+"""Tool → harness handoff for UI bubbles.
+
+Tools never write to `transcript_messages` themselves. When a tool wants
+to emit a `message_kind='component'` row, it appends a `ComponentMessage`
+to `app_context.outbox`. The harness drains the outbox at the end of the
+turn and persists each entry as its own component row.
+
+Keeping this on the context (rather than as a tool return type) means a
+tool can both queue UI *and* return a normal string to the agent — useful
+for tools like `propose_lessons` that hand the agent back a list of IDs.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class ComponentMessage(BaseModel):
+    """One component-kind transcript row, queued by a tool, persisted by the harness."""
+
+    component_name: str
+    props: dict[str, Any]

--- a/web-api/harness/context.py
+++ b/web-api/harness/context.py
@@ -1,8 +1,10 @@
 """Application context and state tracking for agent execution."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from datetime import datetime
 from pydantic import BaseModel, Field
+
+from harness.components import ComponentMessage
 
 # In-memory context storage indexed by session_id
 _contexts: Dict[str, "AppContext"] = {}
@@ -56,6 +58,11 @@ class AppContext(BaseModel):
 
     # Onboarding state (only used for onboarding sessions)
     onboarding: OnboardingState = Field(default_factory=OnboardingState)
+
+    # UI bubbles queued by tools during a turn — drained and persisted by the
+    # harness once the run completes. Tools never write to transcript_messages
+    # directly; they `outbox.append(ComponentMessage(...))` and move on.
+    outbox: List[ComponentMessage] = Field(default_factory=list)
 
     # Timestamp
     updated_at: datetime = Field(default_factory=datetime.now)

--- a/web-api/harness/highlights.py
+++ b/web-api/harness/highlights.py
@@ -1,0 +1,55 @@
+"""Per-flow flavour-word highlighter.
+
+The onboarding agent writes English text peppered with the occasional
+Arabic word (`marhaban`, `duroos`, …). The frontend tints those spans
+and shows a tooltip with the meaning. Rather than asking the agent to
+return `highlights` arrays, the harness scans each text bubble against
+a per-flow vocab and computes the offsets server-side.
+"""
+
+import re
+
+ONBOARDING_VOCAB: dict[str, str] = {
+    "marhaban": "hello",
+    "mishmish": "apricot",
+    "duroos": "lessons",
+    "dars": "lesson",
+    "ahlan": "welcome",
+    "mumtaz": "excellent",
+    "mashallah": "wonderful",
+}
+
+FLOW_VOCAB: dict[str, dict[str, str]] = {
+    "onboarding": ONBOARDING_VOCAB,
+}
+
+
+def compute_highlights(text: str, flow: str | None) -> list[dict]:
+    """Find flavour words in `text`, return DB-shaped highlight rows.
+
+    Case-insensitive match on whole words. Longest words first so a
+    multi-word vocab entry would win over a substring; non-overlapping
+    so we never double-tint a span.
+    """
+    if not flow or flow not in FLOW_VOCAB:
+        return []
+    vocab = FLOW_VOCAB[flow]
+    claimed: list[tuple[int, int]] = []
+    rows: list[dict] = []
+    for word in sorted(vocab, key=len, reverse=True):
+        pattern = rf"\b{re.escape(word)}\b"
+        for m in re.finditer(pattern, text, re.IGNORECASE):
+            start, end = m.start(), m.end()
+            if any(s < end and start < e for s, e in claimed):
+                continue
+            rows.append(
+                {
+                    "word": m.group(),
+                    "meaning": vocab[word],
+                    "start": start,
+                    "end": end,
+                }
+            )
+            claimed.append((start, end))
+    rows.sort(key=lambda h: h["start"])
+    return rows

--- a/web-api/harness/options.py
+++ b/web-api/harness/options.py
@@ -21,10 +21,6 @@ class HarnessOptions:
     # persisting/sending. Tutor only.
     scaffold: bool = False
 
-    # Persist the agent's `final_output` as a tutor message. Onboarding sets
-    # this to False — its visible output goes through the `say` tool.
-    persist_final_output: bool = True
-
     # `flow` field stamped onto every persisted message (user + tutor).
     flow_tag: Optional[str] = None
 
@@ -46,7 +42,6 @@ class HarnessOptions:
         """Project the per-turn fields out for `harness.turn.run_turn`."""
         return TurnConfig(
             scaffold=self.scaffold,
-            persist_final_output=self.persist_final_output,
             flow_tag=self.flow_tag,
             user_none_system_prompt=self.user_none_system_prompt,
         )

--- a/web-api/harness/turn.py
+++ b/web-api/harness/turn.py
@@ -1,19 +1,35 @@
 """Run a single agent turn — channel-agnostic.
 
-`run_turn` invokes the agent, optionally scaffolds the output, persists
-the resulting tutor message, and records analytics. It returns a
-`TurnResult` describing what happened. It does no channel I/O — no
-WebSocket sends, no TTS — those are the channel's job.
+`run_turn` invokes the agent, optionally scaffolds each text output, and
+persists every visible bubble the turn produced. It returns a `TurnResult`
+listing the persisted rows. It does no channel I/O — no WebSocket sends,
+no TTS — those are the channel's job.
+
+The harness owns `transcript_messages`. Two sources land here:
+
+- **Text bubbles** come from any `MessageOutputItem` in `result.new_items`
+  (the LLM's assistant text, including text emitted alongside a tool call).
+  Each one becomes a `message_kind='text'` row, optionally scaffolded
+  (Arabic → Arabizi) and tagged with flow-vocab highlights.
+
+- **Component bubbles** come from `app_context.outbox`, which tools fill
+  during the run by appending `ComponentMessage` instances. Each one
+  becomes a `message_kind='component'` row.
+
+Tools never call `create_transcript_message` themselves.
 """
 
+import json
 import sys
 import time
 from dataclasses import dataclass, field
 from typing import Optional
 
 from agents import Agent, Runner, RunConfig
+from agents.items import ItemHelpers, MessageOutputItem
 
 from harness.context import get_context
+from harness.highlights import compute_highlights
 from harness.scaffolding import generate_scaffolded_text
 from harness.session_manager import get_session
 from services import posthog_service
@@ -29,7 +45,6 @@ class TurnConfig:
     """Per-turn behavior. Decoupled from delivery channel."""
 
     scaffold: bool = False
-    persist_final_output: bool = True
     flow_tag: Optional[str] = None
     user_none_system_prompt: Optional[str] = None
 
@@ -38,10 +53,12 @@ class TurnConfig:
 class TurnResult:
     """Outcome of one agent turn — channels render this however they want."""
 
+    # Concatenated canonical text from all text bubbles, for TTS / analytics.
     canonical_text: str
+    # Concatenated display text (post-scaffold), for the WebSocket "degraded"
+    # fallback path when persistence has nothing to surface.
     display_text: str
-    highlights: list[dict] = field(default_factory=list)
-    persisted_message: Optional[TranscriptMessage] = None
+    persisted_messages: list[TranscriptMessage] = field(default_factory=list)
     timings: dict[str, float] = field(default_factory=dict)
 
 
@@ -50,18 +67,17 @@ async def _run_agent(
     session_id: str,
     user_message: Optional[str],
     user_none_system_prompt: Optional[str],
-) -> str:
-    """Invoke the agent for one turn. Returns its final_output text."""
+):
+    """Invoke the agent for one turn. Returns the SDK RunResult."""
     session = get_session(session_id)
     if not session:
         raise ValueError(f"Session not found: {session_id}")
     context = get_context(session_id)
 
     if user_message is not None:
-        result = await Runner.run(
+        return await Runner.run(
             agent, user_message, session=session, context=context
         )
-        return result.final_output or ""
 
     system_prompt = user_none_system_prompt or "Continue the conversation appropriately."
     system_message = {"role": "system", "content": system_prompt}
@@ -70,49 +86,76 @@ async def _run_agent(
         return history + new_input
 
     run_config = RunConfig(session_input_callback=session_input_callback)
-    result = await Runner.run(
+    return await Runner.run(
         agent,
         [system_message],
         session=session,
         context=context,
         run_config=run_config,
     )
-    return result.final_output or ""
 
 
-async def _maybe_scaffold(
-    canonical_text: str,
-    user_message: Optional[str],
-    config: TurnConfig,
-) -> tuple[str, list[dict]]:
-    if not (config.scaffold and canonical_text.strip()):
-        return canonical_text, []
-    scaffolded = await generate_scaffolded_text(
-        canonical_text, user_message=user_message
-    )
-    return scaffolded.text, scaffolded.highlights
-
-
-async def _maybe_persist(
+async def _persist_text_item(
     session_id: str,
     canonical_text: str,
-    display_text: str,
     config: TurnConfig,
-) -> Optional[TranscriptMessage]:
-    if not (config.persist_final_output and canonical_text.strip()):
-        return None
+    user_message: Optional[str],
+) -> tuple[Optional[TranscriptMessage], str, str]:
+    """Persist one assistant-text item. Returns (row, canonical, display)."""
+    canonical = canonical_text.strip()
+    if not canonical:
+        return None, "", ""
+
+    if config.scaffold:
+        scaffolded = await generate_scaffolded_text(canonical, user_message=user_message)
+        display = scaffolded.text
+        highlights = scaffolded.highlights
+    else:
+        display = canonical
+        highlights = compute_highlights(display, config.flow_tag)
+
     try:
-        return await create_transcript_message(
+        row = await create_transcript_message(
             session_id=session_id,
             message_source="tutor",
             message_kind="text",
-            message_text=display_text,
-            message_text_canonical=canonical_text if config.scaffold else None,
+            message_text=display,
+            message_text_canonical=canonical if config.scaffold else None,
+            highlights=highlights,
             flow=config.flow_tag,
         )
     except Exception as e:
-        _log(f"Failed to persist tutor message: {e}")
-        return None
+        _log(f"Failed to persist tutor text message: {e}")
+        return None, canonical, display
+    return row, canonical, display
+
+
+async def _persist_component_messages(
+    session_id: str,
+    config: TurnConfig,
+) -> list[TranscriptMessage]:
+    """Drain the context outbox and persist each queued ComponentMessage."""
+    context = get_context(session_id)
+    if not context or not context.outbox:
+        return []
+    queued = context.outbox
+    context.outbox = []
+    rows: list[TranscriptMessage] = []
+    for cm in queued:
+        try:
+            row = await create_transcript_message(
+                session_id=session_id,
+                message_source="tutor",
+                message_kind="component",
+                message_text=json.dumps(
+                    {"component_name": cm.component_name, "props": cm.props}
+                ),
+                flow=config.flow_tag,
+            )
+            rows.append(row)
+        except Exception as e:
+            _log(f"Failed to persist component message {cm.component_name}: {e}")
+    return rows
 
 
 def _record_analytics(
@@ -152,19 +195,32 @@ async def run_turn(
     """Run one agent turn end-to-end and return the result."""
     t_start = time.monotonic()
 
-    canonical_text = await _run_agent(
+    run_result = await _run_agent(
         agent, session_id, user_message, config.user_none_system_prompt
     )
     t_after_llm = time.monotonic()
 
-    display_text, highlights = await _maybe_scaffold(
-        canonical_text, user_message, config
-    )
+    persisted: list[TranscriptMessage] = []
+    canonical_parts: list[str] = []
+    display_parts: list[str] = []
+
+    for item in run_result.new_items:
+        if not isinstance(item, MessageOutputItem):
+            continue
+        text = ItemHelpers.text_message_output(item)
+        row, canonical, display = await _persist_text_item(
+            session_id, text, config, user_message
+        )
+        if row is not None:
+            persisted.append(row)
+        if canonical:
+            canonical_parts.append(canonical)
+        if display:
+            display_parts.append(display)
+
     t_after_scaffold = time.monotonic()
 
-    persisted = await _maybe_persist(
-        session_id, canonical_text, display_text, config
-    )
+    persisted.extend(await _persist_component_messages(session_id, config))
 
     timings = {
         "total_ms": round((t_after_scaffold - t_start) * 1000, 1),
@@ -174,9 +230,8 @@ async def run_turn(
     _record_analytics(session_id, timings, config)
 
     return TurnResult(
-        canonical_text=canonical_text,
-        display_text=display_text,
-        highlights=highlights,
-        persisted_message=persisted,
+        canonical_text=" ".join(canonical_parts),
+        display_text=" ".join(display_parts),
+        persisted_messages=persisted,
         timings=timings,
     )

--- a/web-api/harness/turn.py
+++ b/web-api/harness/turn.py
@@ -20,6 +20,7 @@ Tools never call `create_transcript_message` themselves.
 """
 
 import json
+import re
 import sys
 import time
 from dataclasses import dataclass, field
@@ -38,6 +39,22 @@ from services.transcript_service import TranscriptMessage, create_transcript_mes
 
 def _log(msg: str) -> None:
     print(f"[Turn] {msg}", flush=True, file=sys.stderr)
+
+
+# Same shape as the frontend's splitSentences regex — keeps server and client
+# aligned on what counts as a sentence boundary.
+_SENTENCE_RE = re.compile(r"[^.?!]+[.?!]+(?=\s|$)|[^.?!]+$")
+
+
+def _first_sentence(text: str) -> str:
+    """Return just the first sentence of `text` (trimmed).
+
+    Used to clip an agent's reply when the same turn also lands a UI
+    component — components carry the moment, the bubble is the lead-in.
+    Falls back to the original text if no sentence boundary is found.
+    """
+    match = _SENTENCE_RE.search(text)
+    return match.group(0).strip() if match else text.strip()
 
 
 @dataclass(frozen=True)
@@ -204,10 +221,19 @@ async def run_turn(
     canonical_parts: list[str] = []
     display_parts: list[str] = []
 
+    # If a tool queued a UI component this turn, clip the agent's text to its
+    # first sentence. The component is the moment; the bubble is just the
+    # lead-in. Encoded in the harness so we don't have to trust the prompt to
+    # keep the agent from enumerating tile content in chat.
+    context = get_context(session_id)
+    clip_to_first_sentence = bool(context and context.outbox)
+
     for item in run_result.new_items:
         if not isinstance(item, MessageOutputItem):
             continue
         text = ItemHelpers.text_message_output(item)
+        if clip_to_first_sentence:
+            text = _first_sentence(text)
         row, canonical, display = await _persist_text_item(
             session_id, text, config, user_message
         )

--- a/web-app/src/pages/Onboarding.tsx
+++ b/web-app/src/pages/Onboarding.tsx
@@ -276,14 +276,43 @@ const FALLBACK_RE = /(marhaban|mishmish)/gi;
 
 // The agent emits one transcript row per turn; we split it into sentences so
 // each one types in as its own bubble, preserving the multi-line cadence the
-// UI was designed around. Trailing whitespace is trimmed; a fragment without
-// a terminator (e.g. "Hi there") is treated as one sentence. If the regex
-// finds nothing, return the whole text as a single sentence.
-function splitSentences(text: string): string[] {
-  const matches = text.match(/[^.?!]+[.?!]+(?=\s|$)|[^.?!]+$/g);
-  if (!matches) return [text];
-  const trimmed = matches.map((s) => s.trim()).filter((s) => s.length > 0);
-  return trimmed.length > 0 ? trimmed : [text];
+// UI was designed around. Each fragment carries its absolute `[start, end)`
+// span in the original text so per-sentence highlights can be re-aligned.
+type Sentence = { text: string; start: number; end: number };
+
+function splitSentences(text: string): Sentence[] {
+  const matches = [...text.matchAll(/[^.?!]+[.?!]+(?=\s|$)|[^.?!]+$/g)];
+  if (matches.length === 0) return [{ text, start: 0, end: text.length }];
+  const out: Sentence[] = [];
+  for (const m of matches) {
+    const raw = m[0];
+    const rawStart = m.index ?? 0;
+    const leading = raw.length - raw.trimStart().length;
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    const start = rawStart + leading;
+    out.push({ text: trimmed, start, end: start + trimmed.length });
+  }
+  return out.length > 0 ? out : [{ text, start: 0, end: text.length }];
+}
+
+// Re-base whole-message highlight offsets onto a single sentence span.
+// Drops highlights that don't fall entirely inside the sentence.
+function shiftHighlights(
+  highlights: Highlight[] | null | undefined,
+  sentence: Sentence,
+): Highlight[] {
+  if (!highlights || highlights.length === 0) return [];
+  const out: Highlight[] = [];
+  for (const h of highlights) {
+    if (h.start < sentence.start || h.end > sentence.end) continue;
+    out.push({
+      ...h,
+      start: h.start - sentence.start,
+      end: h.end - sentence.start,
+    });
+  }
+  return out;
 }
 
 function textToLine(text: string, highlights: Highlight[] | null | undefined, theme: { tint: string; ink: string }): Line {
@@ -467,25 +496,18 @@ export function Onboarding({ color = 'apricot' }: OnboardingProps) {
     [displayMessages],
   );
 
-  // One transcript row → one Line per sentence. Single-sentence messages keep
-  // their DB highlights (offsets are valid against the full text). Multi-
-  // sentence messages drop them — the offsets would be wrong against each
-  // split fragment. The FALLBACK_RE inside textToLine still tints
-  // "marhaban"/"mishmish" client-side either way.
+  // One transcript row → one Line per sentence. Each sentence inherits the
+  // slice of the message's DB highlights whose offsets fall inside its span,
+  // re-based to sentence-local indices.
   const lines: Line[] = useMemo(() => {
     const result: Line[] = [];
     for (const m of textMessages) {
       const sentences = splitSentences(m.message_text);
-      if (sentences.length <= 1) {
+      for (const sentence of sentences) {
+        const localHighlights = shiftHighlights(m.highlights, sentence);
         result.push(
-          textToLine(m.message_text, m.highlights, { tint: theme.tint, ink: theme.ink }),
+          textToLine(sentence.text, localHighlights, { tint: theme.tint, ink: theme.ink }),
         );
-      } else {
-        for (const sentence of sentences) {
-          result.push(
-            textToLine(sentence, null, { tint: theme.tint, ink: theme.ink }),
-          );
-        }
       }
     }
     return result;


### PR DESCRIPTION
## Summary

Refactors the onboarding flow so **tools never write to `transcript_messages`**. The harness owns all persistence in two passes per turn:

- Walk `result.new_items` for `MessageOutputItem`s → text rows, with flow-vocab highlights computed server-side (`marhaban`, `mishmish`, `duroos`, `ahlan`, …).
- Drain `app_context.outbox` for `ComponentMessage` envelopes queued by tools → component rows.

## Why

The duroos handoff bubble (\"why don't we start with one of these duroos?\") stopped appearing on the final onboarding step after #175 (\"drop say tool\"). Root cause: the onboarding agent had ` tool_use_behavior=StopAtTools(stop_at_tool_names=[\"generate_lessons\"])`, which makes the tool's return value (an empty string) the agent's `final_output`. The harness's empty-text guard then skipped persistence — and any text the LLM emitted alongside the tool call was thrown away. The bubble was being silently dropped on the floor every turn.

Rather than patch around it (a tool param for the bubble, or trusting the prompt to suppress trailing chatter), this PR makes the harness the single owner of `transcript_messages` and decouples it from `final_output` entirely.

## What changed

- **`harness/components.py`** (new) — `ComponentMessage` envelope. Tools that want UI append one to `app_context.outbox`.
- **`harness/highlights.py`** (new) — flow-vocab → meaning lookup. Auto-tints flavour words (`duroos`, `marhaban`, `mishmish`, `ahlan`, `mumtaz`, `mashallah`, …) server-side. Agents/tools never return `highlights` arrays.
- **`harness/turn.py`** — rewritten to walk `result.new_items` and persist every `MessageOutputItem` as a `text` row, then drain the outbox into `component` rows. `TurnResult.persisted_message` → `persisted_messages: list`. Dropped the `persist_final_output` flag — both agents now flow through the same item-walking path.
- **`harness/options.py` / `harness/context.py`** — drop `persist_final_output`, add `outbox: list[ComponentMessage]` to `AppContext`.
- **`generate_lessons` tool** — no more `intro` arg, no more `create_transcript_message` call, no inline highlights. Just validates, marks completion, writes the profile row, queues the `LessonTiles` envelope on the outbox.
- **Onboarding agent** — `StopAtTools` removed. After the tool returns `\"ok\"`, the LLM's post-tool reply is the handoff bubble. Prompt updated to nail it to the duroos line.
- **`channels/chat/turn_dispatcher.py`** — loops over `persisted_messages` instead of sending a single row.
- **`web-app/src/pages/Onboarding.tsx`** — `splitSentences` now returns `{text, start, end}` spans, and a new `shiftHighlights` re-bases DB highlight offsets onto each sentence so `duroos` stays tinted across multi-sentence handoffs.

## Test plan

- [x] Smoke-tested in browser preview: onboarding flow (name → motivation) renders the handoff bubble with `duroos` auto-highlighted, followed by the three lesson tiles.
- [x] DB confirmed: latest turn produces a `text` row (with computed `highlights`) and a `component` row, in that order, neither of them written by the tool.
- [x] `task test` passes (the 2 pre-existing `test_content_service` failures are unrelated to this PR).
- [x] `tsc --noEmit` and ESLint pass for `Onboarding.tsx`.
- [ ] CI green

## Notes for reviewers

- The tutor agent's tools (`propose_lessons`, etc.) still write their own component rows — that's a follow-up to the same pattern, not part of this PR.
- LLM occasionally still dumps tile descriptions in the post-tool reply despite the prompt's \"one sentence only\" instruction. That's prompt-tuning territory now, not structural — the architecture reliably surfaces whatever the model says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)