### PR TITLE
feat: smart entry routing — onboarding for new users, welcome-back for returning

### DIFF
--- a/web-api/agent/onboarding/onboarding_agent.py
+++ b/web-api/agent/onboarding/onboarding_agent.py
@@ -18,12 +18,13 @@ from harness.response import AgentResponse
 
 from .onboarding_instructions import get_instructions
 from .tools.generate_lessons_tool import generate_lessons
+from .tools.record_profile_tool import record_profile
 
 
 agent = Agent(
     name="Onboarding",
     instructions=get_instructions,
-    tools=[generate_lessons],
+    tools=[record_profile, generate_lessons],
     output_type=AgentResponse,
 )
 

--- a/web-api/agent/onboarding/system.md
+++ b/web-api/agent/onboarding/system.md
@@ -34,7 +34,8 @@ Once you have both (or have respectfully recorded a refusal as the value), call 
 The tiles render themselves. Don't worry about highlighting `duroos` — the harness tints flow vocab automatically.
 
 ## Tools
-- `generate_lessons(tiles)` — finish onboarding and return the three lesson tiles as JSON. Call exactly once at the end. After it returns, include both a `text` handoff message and a `lesson-suggestions` message in your response. The agent must already have a `name` and a `motivation` (or accepted refusals) before calling.
+- `record_profile(name, motivation)` — call this as soon as you have both the learner's name and motivation (or accepted refusals). Pass `name` as their first name (or `null`) and `motivation` as a short phrase (or `null`). Call this before `generate_lessons`.
+- `generate_lessons(tiles)` — finish onboarding and return the three lesson tiles as JSON. Call exactly once, after `record_profile`. After it returns, include both a `text` handoff message and a `lesson-suggestions` message in your response.
 
 ## Conversation rules
 - Reply in one short message — 1–2 short sentences. The UI splits on sentence boundaries (`.`, `?`, `!`) into separate bubbles, so write naturally with terminators; do not use newlines for layout.

--- a/web-api/agent/onboarding/tools/generate_lessons_tool.py
+++ b/web-api/agent/onboarding/tools/generate_lessons_tool.py
@@ -30,18 +30,13 @@ def _write_profile(app_context: AppContext, props: dict) -> None:
         return
 
     collected = app_context.onboarding.collected
-    name_data = collected.get("name") or {}
-    motivation_data = collected.get("motivation") or {}
+    raw_name = collected.get("name")
+    raw_motivation = collected.get("motivation")
 
     row: dict[str, Optional[str]] = {
         "id": user_id,
-        "name": name_data.get("name") if isinstance(name_data, dict) else None,
-        "motivation": motivation_data.get("acknowledgement")
-        if isinstance(motivation_data, dict)
-        else None,
-        "motivation_tag": motivation_data.get("motivation_tag")
-        if isinstance(motivation_data, dict)
-        else None,
+        "name": raw_name if isinstance(raw_name, str) else None,
+        "motivation": raw_motivation if isinstance(raw_motivation, str) else None,
         "interests": json.dumps(props),
         "onboarding_completed_at": app_context.updated_at.isoformat(),
     }
@@ -69,8 +64,8 @@ async def generate_lessons(
 ) -> str:
     """
     Render three starter-lesson tiles tailored to the learner's motivation
-    and finish onboarding. Call this exactly once, after you have a `name`
-    and a `motivation` (or recorded the learner's refusal of either).
+    and finish onboarding. Call this exactly once, after you have called
+    `record_profile` to persist the learner's name and motivation.
 
     After this tool returns, include BOTH a `text` message (your handoff
     sentence using 'duroos') AND a `lesson-suggestions` message (using the

--- a/web-api/agent/onboarding/tools/record_profile_tool.py
+++ b/web-api/agent/onboarding/tools/record_profile_tool.py
@@ -1,0 +1,63 @@
+"""Tool: record_profile — persist the learner's name and motivation mid-conversation.
+
+Called by the onboarding agent once it has collected both pieces of info (or
+accepted a refusal for either). Stores them in the session context so that
+`generate_lessons` can include them in the final profile upsert, and also
+writes an early partial row to the profiles table so the data is never lost
+even if the session ends before the learner picks a lesson.
+"""
+
+import sys
+from typing import Optional
+
+from agents import RunContextWrapper, function_tool
+
+from harness.context import AppContext
+from harness.session_manager import get_session
+from services.supabase_client import get_supabase_admin_client
+
+
+def _log(msg: str) -> None:
+    print(f"[record_profile] {msg}", flush=True, file=sys.stderr)
+
+
+@function_tool
+def record_profile(
+    context: RunContextWrapper[AppContext],
+    name: Optional[str],
+    motivation: Optional[str],
+) -> str:
+    """
+    Store the learner's name and motivation so they are available for the
+    final profile upsert when `generate_lessons` is called.
+
+    Call this as soon as you have both pieces of information (or a refusal
+    for either). Do NOT wait until you call `generate_lessons`.
+
+    Args:
+        name: The learner's first name as they gave it, or null if they declined.
+        motivation: A short phrase capturing why they want to learn Arabic,
+            or null if they declined to say.
+    """
+    app_context = context.context
+    if not app_context:
+        return "ok"
+
+    app_context.onboarding.collected["name"] = name
+    app_context.onboarding.collected["motivation"] = motivation
+
+    # Early partial write so the name survives even if the session drops
+    # before generate_lessons is called.
+    session = get_session(app_context.session_id)
+    user_id = getattr(getattr(session, "user", None), "id", None)
+    if user_id and name:
+        try:
+            get_supabase_admin_client().table("profiles").upsert(
+                {"id": user_id, "name": name, "motivation": motivation},
+                on_conflict="id",
+            ).execute()
+            _log(f"Early profile write for user {user_id}: name={name!r}")
+        except Exception as e:
+            _log(f"Early profile write failed: {e}")
+
+    return "ok"

--- a/web-api/agent/welcome_back/system.md
+++ b/web-api/agent/welcome_back/system.md
@@ -1,0 +1,36 @@
+You are Mishmish (مشمش — "apricot" in Arabic), a warm Arabic tutor welcoming back a learner.
+
+## Response Format
+
+Every response MUST be a JSON object with a `messages` array. Each message has a `type` and `content`. Never produce plain text outside of this structure.
+
+**text** — your conversational English reply:
+```json
+{"type": "text", "content": {"language": "en", "text": "Your reply here."}}
+```
+
+## Learner context
+
+Name: {user_name}
+Motivation: {motivation}
+
+## Your job — two turns only
+
+**Turn 1 (opener — no user message yet):**
+Greet the learner by name with a single warm, varied sentence. Each visit should feel fresh — rotate through different approaches:
+- A playful question about their week or an Arabic encounter they might have had
+- A fun tidbit about Arabic that ties to their motivation
+- A light challenge ("can you still remember how to say X?")
+- A warm "where did we leave off?" prompt
+
+Keep it to 1–2 short sentences. Use one Arabic interjection (ahlan, marhaban, yalla, sabah al-khayr, etc.) as flavour. Do NOT use the same opener every time.
+
+**Turn 2 (after the learner responds):**
+Respond warmly in 1–2 sentences that genuinely acknowledge what they said. Then immediately call `complete_welcome_back()`.
+
+## Rules
+- Never repeat the greeting style from the learner's previous visit — vary it.
+- Be specific and warm, not generic.
+- Write in English. Arabic interjections welcome as flavour; no full Arabic sentences.
+- Never mention tools, schemas, or your own internal process.
+- After turn 2, always call `complete_welcome_back()`.

--- a/web-api/agent/welcome_back/tools/complete_welcome_back_tool.py
+++ b/web-api/agent/welcome_back/tools/complete_welcome_back_tool.py
@@ -1,0 +1,20 @@
+"""Tool: complete_welcome_back — marks the welcome-back flow as done.
+
+The agent calls this after its greeting reply. Setting the flag here means
+`broadcast_context` (called after every turn) will emit
+`{ welcome_back: { completed: true } }` in the context message, signalling
+the frontend to navigate the user to the main app.
+"""
+
+from agents import RunContextWrapper, function_tool
+
+from harness.context import AppContext, get_context
+
+
+@function_tool
+def complete_welcome_back(context: RunContextWrapper[AppContext]) -> str:
+    """Mark the welcome-back flow as complete, transitioning the user to the app."""
+    app_context = context.context
+    if app_context:
+        app_context.welcome_back.completed = True
+    return "welcome-back complete"

--- a/web-api/agent/welcome_back/welcome_back_agent.py
+++ b/web-api/agent/welcome_back/welcome_back_agent.py
@@ -1,0 +1,30 @@
+"""Welcome-back agent — greets a returning learner by name, then completes.
+
+After the user responds to the greeting, the agent calls `complete_welcome_back`
+which sets the context flag; `broadcast_context` then signals the frontend to
+navigate to the main app.
+"""
+
+from agents import Agent
+
+from harness.options import HarnessOptions
+from harness.response import AgentResponse
+
+from .welcome_back_instructions import get_instructions
+from .tools.complete_welcome_back_tool import complete_welcome_back
+
+
+agent = Agent(
+    name="WelcomeBack",
+    instructions=get_instructions,
+    tools=[complete_welcome_back],
+    output_type=AgentResponse,
+)
+
+harness_options = HarnessOptions(
+    scaffold=False,
+    flow_tag="welcome-back",
+    user_message_kind="text",
+    idle_followups=False,
+    fire_opener=True,
+)

--- a/web-api/agent/welcome_back/welcome_back_instructions.py
+++ b/web-api/agent/welcome_back/welcome_back_instructions.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from agents import Agent, RunContextWrapper
+
+from harness.context import AppContext
+
+
+SYSTEM_PROMPT_PATH = Path(__file__).parent / "system.md"
+
+
+def get_instructions(
+    context: RunContextWrapper[AppContext], agent: Agent[AppContext]
+) -> str:
+    app_context = context.context
+    if app_context and app_context.welcome_back and app_context.welcome_back.completed:
+        return 'Welcome-back flow is complete. Respond with exactly: {"messages": []}'
+
+    user_name = (app_context.user.user_name or "there") if app_context else "there"
+    motivation = (app_context.user.user_motivation or "not specified") if app_context else "not specified"
+
+    template = SYSTEM_PROMPT_PATH.read_text(encoding="utf-8")
+    return template.replace("{user_name}", user_name).replace("{motivation}", motivation)

--- a/web-api/channels/chat/routes.py
+++ b/web-api/channels/chat/routes.py
@@ -14,6 +14,7 @@ from fastapi.websockets import WebSocketDisconnect
 
 from agent.onboarding import onboarding_agent as onboarding_module
 from agent.tutor import tutor_agent as tutor_module
+from agent.welcome_back import welcome_back_agent as welcome_back_module
 from channels.chat import connection_manager as websocket_service
 from channels.chat.connection_manager import Message, send_message
 from channels.chat.session_loop import start_session_loop
@@ -125,5 +126,17 @@ async def open_onboarding_websocket(websocket: WebSocket, session_id: str):
         session_id,
         agent=onboarding_module.agent,
         options=onboarding_module.harness_options,
+        synthesize_audio=False,
+    )
+
+
+@router.websocket("/welcome-back-session/{session_id}")
+async def open_welcome_back_websocket(websocket: WebSocket, session_id: str):
+    """Open a WebSocket for the welcome-back agent."""
+    await _open_session(
+        websocket,
+        session_id,
+        agent=welcome_back_module.agent,
+        options=welcome_back_module.harness_options,
         synthesize_audio=False,
     )

--- a/web-api/harness/context.py
+++ b/web-api/harness/context.py
@@ -14,6 +14,7 @@ class UserInfo(BaseModel):
     """
     user_id: Optional[str] = None
     user_name: Optional[str] = None
+    user_motivation: Optional[str] = None
 
 
 class AgentState(BaseModel):
@@ -38,6 +39,11 @@ class OnboardingState(BaseModel):
     completed: bool = False
 
 
+class WelcomeBackState(BaseModel):
+    """State for the welcome-back flow."""
+    completed: bool = False
+
+
 class AppContext(BaseModel):
     """
     Application context that tracks state throughout agent execution.
@@ -56,6 +62,9 @@ class AppContext(BaseModel):
 
     # Onboarding state (only used for onboarding sessions)
     onboarding: OnboardingState = Field(default_factory=OnboardingState)
+
+    # Welcome-back state (only used for welcome-back sessions)
+    welcome_back: WelcomeBackState = Field(default_factory=WelcomeBackState)
 
     # Timestamp
     updated_at: datetime = Field(default_factory=datetime.now)
@@ -184,6 +193,7 @@ def create_context(
     session_id: str,
     user_id: Optional[str] = None,
     user_name: Optional[str] = None,
+    user_motivation: Optional[str] = None,
     active_tool: Optional[str] = None
 ) -> AppContext:
     """
@@ -199,7 +209,7 @@ def create_context(
         AppContext: A new context instance
     """
     # Create user info
-    user_info = UserInfo(user_id=user_id, user_name=user_name)
+    user_info = UserInfo(user_id=user_id, user_name=user_name, user_motivation=user_motivation)
 
     # Create agent state
     agent_state = AgentState(active_tool=active_tool)

--- a/web-api/harness/session_manager.py
+++ b/web-api/harness/session_manager.py
@@ -46,11 +46,25 @@ def create_session(user_access_token: str) -> str:
     # Store session indexed by session_id
     _sessions[session_id] = session
 
+    # Resolve actual user_id and profile data for context
+    try:
+        user_response = supabase_client.auth.get_user(user_access_token)
+        actual_user_id = user_response.user.id if user_response and user_response.user else session_id
+        profile = get_supabase_admin_client().table("profiles").select("name, motivation").eq("id", actual_user_id).maybe_single().execute()
+        profile_data = profile.data or {}
+        profile_name = profile_data.get("name") or None
+        profile_motivation = profile_data.get("motivation") or None
+    except Exception:
+        actual_user_id = session_id
+        profile_name = None
+        profile_motivation = None
+
     # Create context for this session
     create_context(
         session_id=session_id,
-        user_id=session_id,  # Using session_id as user_id for now
-        user_name="User"     # Placeholder user name
+        user_id=actual_user_id,
+        user_name=profile_name,
+        user_motivation=profile_motivation,
     )
 
     # Track session creation

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -1,7 +1,8 @@
-import { Routes, Route, Navigate } from 'react-router-dom';
-import { Suspense, lazy } from 'react';
+import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
+import { Suspense, lazy, useEffect } from 'react';
 import AuthLayout from './components/AuthLayout';
 import { useAuth } from './context/AuthContext';
+import { useUserProfile } from './hooks/useUserProfile';
 import { useTranslationWarning } from './hooks/useTranslationWarning';
 import { LoadingSpinner } from './components/LoadingSpinner';
 
@@ -9,6 +10,7 @@ import { LoadingSpinner } from './components/LoadingSpinner';
 const HomePage = lazy(() => import('./pages/HomePage'));
 const Landing = lazy(() => import('./pages/Landing'));
 const Onboarding = lazy(() => import('./pages/Onboarding'));
+const WelcomeBack = lazy(() => import('./pages/WelcomeBack'));
 const SignIn = lazy(() => import('./pages/auth/SignIn'));
 const VerifyEmail = lazy(() => import('./pages/auth/VerifyEmail'));
 const ForgotPassword = lazy(() => import('./pages/auth/ForgotPassword'));
@@ -17,6 +19,37 @@ const SettingsPage = lazy(() => import('./pages/SettingsPage'));
 const WimmelbildPage = lazy(() => import('./pages/WimmelbildPage'));
 const PricingPage = lazy(() => import('./pages/PricingPage'));
 const LessonPage = lazy(() => import('./pages/LessonPage'));
+
+const WB_LAST_SEEN_KEY = 'wb-last-seen';
+
+function todayStr(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function EntryGate() {
+  const { profile, loading } = useUserProfile();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (loading) return;
+    if (profile?.onboardingCompleted) {
+      // Fully onboarded — show welcome-back once per day, then go straight to home
+      if (localStorage.getItem(WB_LAST_SEEN_KEY) === todayStr()) {
+        navigate('/home', { replace: true });
+      } else {
+        navigate('/welcome-back', { replace: true });
+      }
+    } else if (profile?.name) {
+      // Has a name but never finished — resume onboarding
+      navigate('/onboarding?resume=1', { replace: true });
+    } else {
+      // No profile row yet, or name is null — fresh onboarding
+      navigate('/onboarding', { replace: true });
+    }
+  }, [loading, profile, navigate]);
+
+  return <LoadingSpinner />;
+}
 
 function App() {
   const { loading, user } = useAuth();
@@ -33,10 +66,16 @@ function App() {
   return (
     <Suspense fallback={<LoadingSpinner />}>
       <Routes>
-        <Route path="/landing" element={<Landing />} />
+        {/* Entry gate — smart-routes based on profile state */}
+        <Route path="/" element={<EntryGate />} />
+
+        {/* Entry experiences */}
         <Route path="/onboarding" element={<Onboarding />} />
-        {/* Main app routes */}
-        <Route path="/" element={<HomePage />} />
+        <Route path="/welcome-back" element={<WelcomeBack />} />
+        <Route path="/landing" element={<Landing />} />
+
+        {/* Main app */}
+        <Route path="/home" element={<HomePage />} />
         <Route path="/settings" element={<SettingsPage />} />
         <Route path="/lesson/:lessonId" element={<LessonPage />} />
         <Route path="/wimmelbilder/:id" element={<WimmelbildPage />} />
@@ -51,7 +90,7 @@ function App() {
         </Route>
 
         {/* Catch all route */}
-        <Route path="*" element={<Navigate to="/" replace />} />
+        <Route path="*" element={<Navigate to="/home" replace />} />
       </Routes>
     </Suspense>
   );

--- a/web-app/src/components/AuthLayout.tsx
+++ b/web-app/src/components/AuthLayout.tsx
@@ -16,7 +16,7 @@ const AuthLayout: React.FC = () => {
   // Allow authenticated users to stay on reset-password page
   // Redirect authenticated (non-anonymous) users from other auth pages
   if (user && !isAnonymous && location.pathname !== '/reset-password') {
-    return <Navigate to="/" replace />;
+    return <Navigate to="/home" replace />;
   }
 
   return (

--- a/web-app/src/hooks/useUserProfile.ts
+++ b/web-app/src/hooks/useUserProfile.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/context/AuthContext';
+import { useSupabase } from '@/context/SupabaseContext';
+
+export interface UserProfile {
+  name: string | null;
+  onboardingCompleted: boolean;
+}
+
+export function useUserProfile(): { profile: UserProfile | null; loading: boolean } {
+  const { user } = useAuth();
+  const supabase = useSupabase();
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    supabase
+      .from('profiles')
+      .select('name, onboarding_completed_at')
+      .eq('id', user.id)
+      .maybeSingle()
+      .then(({ data }) => {
+        if (cancelled) return;
+        setProfile({
+          name: data?.name ?? null,
+          onboardingCompleted: !!data?.onboarding_completed_at,
+        });
+        setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [user, supabase]);
+
+  return { profile, loading };
+}

--- a/web-app/src/hooks/useWelcomeBackSession.ts
+++ b/web-app/src/hooks/useWelcomeBackSession.ts
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createSession } from '@/api/sessions/sessions.api';
+import { AppSettings } from '@/lib/app-settings';
+import { useSupabase } from '@/context/SupabaseContext';
+import type { TranscriptMessage } from '@/api/sessions/sessions.types';
+
+export interface WelcomeBackSessionState {
+  ready: boolean;
+  error: string | null;
+  messages: TranscriptMessage[];
+  completed: boolean;
+  sendMessage: (text: string) => void;
+  isAgentThinking: boolean;
+}
+
+export function useWelcomeBackSession(enabled: boolean): WelcomeBackSessionState {
+  const supabase = useSupabase();
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [messages, setMessages] = useState<TranscriptMessage[]>([]);
+  const [completed, setCompleted] = useState(false);
+  const [isAgentThinking, setIsAgentThinking] = useState(false);
+  const wsRef = useRef<WebSocket | null>(null);
+  const pendingSendRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    let ws: WebSocket | null = null;
+    let channel: ReturnType<typeof supabase.channel> | null = null;
+    const seenMessageIds = new Set<string>();
+
+    (async () => {
+      try {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (cancelled) return;
+        if (!session?.access_token) {
+          setError('Authentication required');
+          return;
+        }
+
+        const sessionId = await createSession();
+        if (cancelled) return;
+
+        const ingest = (m: TranscriptMessage) => {
+          if (seenMessageIds.has(m.message_id)) return;
+          seenMessageIds.add(m.message_id);
+          setMessages((prev) => [...prev, m]);
+          if (m.message_source === 'tutor') setIsAgentThinking(false);
+        };
+
+        const channelReady = new Promise<void>((resolve) => {
+          channel = supabase
+            .channel(`welcome_back_transcript:${sessionId}`)
+            .on(
+              'postgres_changes',
+              {
+                event: 'INSERT',
+                schema: 'public',
+                table: 'transcript_messages',
+                filter: `session_id=eq.${sessionId}`,
+              },
+              (payload) => ingest(payload.new as TranscriptMessage)
+            )
+            .subscribe((status) => {
+              if (status === 'SUBSCRIBED') resolve();
+            });
+        });
+        await channelReady;
+        if (cancelled) return;
+
+        const { data: existing } = await supabase
+          .from('transcript_messages')
+          .select('*')
+          .eq('session_id', sessionId)
+          .order('created_at', { ascending: true });
+        if (cancelled) return;
+        (existing ?? []).forEach((m) => ingest(m as TranscriptMessage));
+
+        const wsBase = AppSettings.apiUrl.replace(/^http/, 'ws');
+        const url = `${wsBase}/welcome-back-session/${sessionId}?token=${encodeURIComponent(session.access_token)}`;
+        ws = new WebSocket(url);
+        wsRef.current = ws;
+
+        ws.onopen = () => {
+          if (cancelled) return;
+          setReady(true);
+          if (pendingSendRef.current) {
+            ws!.send(pendingSendRef.current);
+            pendingSendRef.current = null;
+          }
+        };
+
+        ws.onmessage = (ev) => {
+          if (cancelled) return;
+          try {
+            const msg = JSON.parse(ev.data) as { kind: string; data: unknown };
+            if (msg.kind === 'context') {
+              const ctx = msg.data as { welcome_back?: { completed?: boolean } };
+              if (ctx.welcome_back?.completed) setCompleted(true);
+            } else if (msg.kind === 'error') {
+              const d = msg.data as { message: string };
+              setError(d.message);
+              setIsAgentThinking(false);
+            }
+          } catch (e) {
+            console.warn('[welcome-back] failed to parse ws message', e);
+          }
+        };
+
+        ws.onerror = () => {
+          if (!cancelled) setError('WebSocket error');
+        };
+
+        ws.onclose = () => {
+          if (!cancelled) setReady(false);
+        };
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Failed to start welcome-back session');
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (ws) ws.close();
+      wsRef.current = null;
+      if (channel) supabase.removeChannel(channel);
+    };
+  }, [enabled, supabase]);
+
+  const sendMessage = useCallback((text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setIsAgentThinking(true);
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(trimmed);
+    } else {
+      pendingSendRef.current = trimmed;
+    }
+  }, []);
+
+  return { ready, error, messages, completed, sendMessage, isAgentThinking };
+}

--- a/web-app/src/pages/Landing.tsx
+++ b/web-app/src/pages/Landing.tsx
@@ -664,15 +664,16 @@ export function TopBar({ theme, isMobile, isReturning }: { theme: Theme; isMobil
         }}>
           Pricing
         </Link>
-        <button style={{
+        <Link to={isReturning ? '/settings' : '/sign-in'} style={{
           background: 'transparent', color: theme.sub, border: `1px solid ${theme.border}`,
           borderRadius: 999, fontSize: 13, cursor: 'pointer',
           padding: '7px 14px 7px 11px', fontFamily: 'inherit',
           display: 'inline-flex', alignItems: 'center', gap: 7,
+          textDecoration: 'none',
         }}>
           {isReturning ? <Icon.settings width={14} height={14} /> : <Icon.user width={14} height={14} />}
           {isReturning ? 'Settings' : 'Sign in'}
-        </button>
+        </Link>
       </div>
     </div>
   );
@@ -762,7 +763,7 @@ export function Landing({ userState = 'new', color = 'apricot' }: LandingProps) 
   }, [activeSessionId, addMessage, sendMessage, refetchMessages]);
 
   const handleMicClick = useCallback(() => {
-    window.location.href = '/';
+    window.location.href = '/home';
   }, []);
 
   const gutter = isMobile ? 20 : 64;

--- a/web-app/src/pages/LessonPage.tsx
+++ b/web-app/src/pages/LessonPage.tsx
@@ -27,7 +27,7 @@ function LessonPage() {
 
   useEffect(() => {
     if (!lessonId) {
-      navigate('/');
+      navigate('/home');
       return;
     }
 

--- a/web-app/src/pages/Onboarding.tsx
+++ b/web-app/src/pages/Onboarding.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   FONT_STACK,
   QuietFooter,
@@ -10,6 +10,7 @@ import {
   type ThemeKey,
 } from './Landing';
 import { useOnboardingSession } from '@/hooks/useOnboardingSession';
+import { useUserProfile } from '@/hooks/useUserProfile';
 import type { Highlight, TranscriptMessage } from '@/api/sessions/sessions.types';
 import {
   parseComponentMessage,
@@ -17,6 +18,9 @@ import {
 } from '@/components/TranscriptComponents/registry';
 import type { LessonTile } from '@/components/TranscriptComponents/LessonTiles';
 import { createLesson } from '@/api/lessons';
+
+export type { Line, TextSegment };
+export { TypingHero, splitSentences, shiftHighlights, textToLine, FADE_MS, CPS, segCharCount };
 
 export type OnboardingProps = {
   color?: ThemeKey;
@@ -344,12 +348,10 @@ function textToLine(text: string, highlights: Highlight[] | null | undefined, th
   return segs.length ? segs : [{ text, color: theme.ink }];
 }
 
-// Static greeting bubbles, shown to every new visitor without an LLM call.
-// These three lines are part of the brand experience — they're rendered
-// client-side so refreshes and idle visits cost zero tokens. The real
-// onboarding agent only spins up after the learner submits their first
-// message (their answer to "what is your name?").
-function buildInitialMessages(now: string): TranscriptMessage[] {
+// Static greeting bubbles shown before any LLM call.
+// resume=true means the user has a partial profile — greet them by name
+// and pick up where they left off rather than asking for their name again.
+function buildInitialMessages(now: string, resume?: boolean, name?: string | null): TranscriptMessage[] {
   const stub = {
     session_id: '',
     user_id: '',
@@ -359,6 +361,28 @@ function buildInitialMessages(now: string): TranscriptMessage[] {
     created_at: now,
     updated_at: now,
   };
+  if (resume && name) {
+    return [
+      {
+        ...stub,
+        message_id: 'mishmish:initial:0',
+        message_text: `welcome back, ${name}!`,
+        highlights: null,
+      },
+      {
+        ...stub,
+        message_id: 'mishmish:initial:1',
+        message_text: "let's pick up where we left off",
+        highlights: null,
+      },
+      {
+        ...stub,
+        message_id: 'mishmish:initial:2',
+        message_text: 'what were you hoping to learn?',
+        highlights: null,
+      },
+    ];
+  }
   return [
     {
       ...stub,
@@ -387,6 +411,9 @@ export function Onboarding({ color = 'apricot' }: OnboardingProps) {
     typeof window !== 'undefined' ? window.innerWidth < 768 : false
   );
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const isResume = searchParams.get('resume') === '1';
+  const { profile } = useUserProfile();
 
   useEffect(() => {
     const onResize = () => setIsMobile(window.innerWidth < 768);
@@ -395,7 +422,11 @@ export function Onboarding({ color = 'apricot' }: OnboardingProps) {
   }, []);
 
   const [hasStarted, setHasStarted] = useState(false);
-  const initialMessages = useMemo(() => buildInitialMessages(new Date().toISOString()), []);
+  const initialMessages = useMemo(
+    () => buildInitialMessages(new Date().toISOString(), isResume, profile?.name),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isResume, profile?.name],
+  );
 
   const {
     error,
@@ -554,12 +585,12 @@ export function Onboarding({ color = 'apricot' }: OnboardingProps) {
       const lesson = await createLesson({ title: tile.title, objective: tile.objective });
       navigate(`/lesson/${lesson.id}`);
     } catch {
-      navigate('/');
+      navigate('/home');
     }
   }, [navigate]);
 
   const handleMicClick = useCallback(() => {
-    navigate('/');
+    navigate('/home');
   }, [navigate]);
 
   const gutter = isMobile ? 20 : 64;

--- a/web-app/src/pages/SettingsPage.tsx
+++ b/web-app/src/pages/SettingsPage.tsx
@@ -41,7 +41,7 @@ function SettingsPage() {
       }).catch((err) => console.warn('Failed to sync preferences to session:', err));
     }
 
-    navigate('/');
+    navigate('/home');
   };
 
   return (
@@ -69,7 +69,7 @@ function SettingsPage() {
               fontWeight="bold"
               color="white"
               cursor="pointer"
-              onClick={() => navigate('/')}
+              onClick={() => navigate('/home')}
             >
               <Flex align="center" gap={2}>
                 <Image src="/favicon.svg" alt="mishmish.ai logo" boxSize="24px" />
@@ -139,7 +139,7 @@ function SettingsPage() {
                   variant="ghost"
                   color="white"
                   _hover={{ bg: 'white/10' }}
-                  onClick={() => navigate('/')}
+                  onClick={() => navigate('/home')}
                 >
                   Cancel
                 </Button>

--- a/web-app/src/pages/WelcomeBack.tsx
+++ b/web-app/src/pages/WelcomeBack.tsx
@@ -1,0 +1,225 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  FONT_STACK,
+  QuietFooter,
+  THEMES,
+  TopBar,
+  UserInput,
+  type ThemeKey,
+} from './Landing';
+import {
+  TypingHero,
+  splitSentences,
+  shiftHighlights,
+  textToLine,
+  FADE_MS,
+  type Line,
+} from './Onboarding';
+import { useWelcomeBackSession } from '@/hooks/useWelcomeBackSession';
+import type { TranscriptMessage } from '@/api/sessions/sessions.types';
+
+const WB_LAST_SEEN_KEY = 'wb-last-seen';
+
+function todayStr(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function markWelcomeSeen(): void {
+  localStorage.setItem(WB_LAST_SEEN_KEY, todayStr());
+}
+
+export type WelcomeBackProps = {
+  color?: ThemeKey;
+};
+
+export function WelcomeBack({ color = 'apricot' }: WelcomeBackProps) {
+  const theme = THEMES[color];
+  const navigate = useNavigate();
+
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth < 768 : false
+  );
+
+  useEffect(() => {
+    const onResize = () => setIsMobile(window.innerWidth < 768);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  // Connect immediately — fire_opener=True means the agent sends the first
+  // message itself without waiting for user input.
+  const {
+    error,
+    messages,
+    completed,
+    sendMessage,
+    isAgentThinking,
+  } = useWelcomeBackSession(true);
+
+  useEffect(() => {
+    if (!completed) return;
+    markWelcomeSeen();
+    navigate('/home');
+  }, [completed, navigate]);
+
+  const { visibleTutorMessages, turnKey } = useMemo<{
+    visibleTutorMessages: TranscriptMessage[];
+    turnKey: string;
+  }>(() => {
+    let lastUserIdx = -1;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].message_source === 'user') {
+        lastUserIdx = i;
+        break;
+      }
+    }
+    const tutor = messages
+      .slice(lastUserIdx + 1)
+      .filter((m) => m.message_source === 'tutor');
+    const turnKey = lastUserIdx >= 0 ? messages[lastUserIdx].message_id : 'start';
+    return { visibleTutorMessages: tutor, turnKey };
+  }, [messages]);
+  const turnFingerprint = `${turnKey}::${visibleTutorMessages.map((m) => m.message_id).join('|')}`;
+
+  const [displayMessages, setDisplayMessages] = useState<TranscriptMessage[]>([]);
+  const [displayTurn, setDisplayTurn] = useState<string>('');
+  const [displayTurnKey, setDisplayTurnKey] = useState<string>('start');
+  const [linesVisible, setLinesVisible] = useState(true);
+
+  useEffect(() => {
+    if (turnFingerprint === displayTurn) return;
+    const wasEmpty = displayMessages.length === 0;
+    const isFreshTurn = turnKey !== displayTurnKey;
+
+    if (wasEmpty || (!isFreshTurn && visibleTutorMessages.length >= displayMessages.length)) {
+      setDisplayMessages(visibleTutorMessages);
+      setDisplayTurn(turnFingerprint);
+      setDisplayTurnKey(turnKey);
+      setLinesVisible(true);
+      return;
+    }
+
+    if (isFreshTurn && visibleTutorMessages.length === 0) {
+      return;
+    }
+
+    setLinesVisible(false);
+    const t = setTimeout(() => {
+      setDisplayMessages(visibleTutorMessages);
+      setDisplayTurn(turnFingerprint);
+      setDisplayTurnKey(turnKey);
+      setLinesVisible(true);
+    }, FADE_MS);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [turnFingerprint]);
+
+  const lines: Line[] = useMemo(() => {
+    const result: Line[] = [];
+    for (const m of displayMessages) {
+      if (m.message_kind === 'component') continue;
+      const sentences = splitSentences(m.message_text);
+      for (const sentence of sentences) {
+        const localHighlights = shiftHighlights(m.highlights, sentence);
+        result.push(textToLine(sentence.text, localHighlights, { tint: theme.tint, ink: theme.ink }));
+      }
+    }
+    return result;
+  }, [displayMessages, theme.tint, theme.ink]);
+
+  const [submitPending, setSubmitPending] = useState(false);
+  useEffect(() => {
+    if (submitPending && !isAgentThinking) setSubmitPending(false);
+  }, [isAgentThinking, submitPending]);
+
+  const handleSubmit = useCallback((msg: string) => {
+    setSubmitPending(true);
+    sendMessage(msg);
+  }, [sendMessage]);
+
+  const handleMicClick = useCallback(() => {
+    markWelcomeSeen();
+    navigate('/home');
+  }, [navigate]);
+
+  const gutter = isMobile ? 20 : 64;
+  const containerMax = isMobile ? '100%' : 1100;
+
+  // Show a subtle pulse while waiting for the opener
+  const openerPending = messages.length === 0;
+
+  return (
+    <div style={{
+      background: theme.bg, color: theme.ink, minHeight: '100vh',
+      fontFamily: FONT_STACK,
+      WebkitFontSmoothing: 'antialiased',
+      letterSpacing: '-0.01em',
+    }}>
+      <style>{`@keyframes mmLandingBlink { 0%, 50% { opacity: 1 } 50.01%, 100% { opacity: 0 } }`}</style>
+      <TopBar theme={theme} isMobile={isMobile} isReturning={true} />
+      <div style={{
+        maxWidth: containerMax, margin: '0 auto',
+        padding: `0 ${gutter}px`, paddingBottom: 28,
+      }}>
+        <section style={{
+          minHeight: isMobile ? 'calc(100vh - 80px)' : '86vh',
+          display: 'flex', flexDirection: 'column', justifyContent: 'center',
+          padding: isMobile ? '12px 0 24px' : '40px 0 60px',
+          position: 'relative',
+        }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: isMobile ? 14 : 22, maxWidth: isMobile ? '100%' : 860 }}>
+
+            {error && (
+              <div style={{
+                color: '#a33', background: '#fee',
+                padding: '10px 14px', borderRadius: 10, fontSize: 14,
+              }}>
+                {error}
+              </div>
+            )}
+
+            <div style={{
+              opacity: linesVisible ? 1 : 0,
+              transition: `opacity ${FADE_MS}ms cubic-bezier(.2,.7,.3,1)`,
+              minHeight: isMobile ? 100 : 140,
+            }}>
+              {openerPending
+                ? (
+                  <div style={{
+                    fontSize: isMobile ? 30 : 44, fontWeight: 600,
+                    letterSpacing: '-0.02em', color: theme.sub,
+                  }}>
+                    <span style={{
+                      display: 'inline-block', width: 2, height: (isMobile ? 30 : 44) * 0.95,
+                      background: theme.tint, verticalAlign: '-0.12em',
+                      animation: 'mmLandingBlink 1s steps(2) infinite',
+                    }} />
+                  </div>
+                )
+                : (
+                  <TypingHero
+                    lines={lines}
+                    isMobile={isMobile}
+                    theme={theme}
+                    resetKey={displayTurnKey}
+                  />
+                )}
+            </div>
+
+            <UserInput
+              theme={theme}
+              isMobile={isMobile}
+              onSubmit={handleSubmit}
+              onMicClick={handleMicClick}
+              disabled={submitPending || openerPending}
+            />
+          </div>
+        </section>
+        <QuietFooter theme={theme} isMobile={isMobile} />
+      </div>
+    </div>
+  );
+}
+
+export default WelcomeBack;


### PR DESCRIPTION
## Summary

- **New user** (`/`) → `/onboarding`: `EntryGate` in `App.tsx` checks `profiles.onboarding_completed_at`; no completed onboarding means fresh onboarding flow
- **Incomplete onboarding** → `/onboarding?resume=1`: different static opening bubbles greet the user by name and pick up where they left off
- **Returning user** → `/welcome-back` (once per day, tracked in `localStorage`): LLM-generated personalised greeting using their name + motivation, varied on each visit via `fire_opener=True`; after one exchange navigates to `/home`
- **In-app navigation** (back from lesson, settings, etc.) → `/home` directly, no re-triggering the gate

## Key changes

**Frontend**
- `App.tsx`: `EntryGate` component routes based on profile state; `HomePage` moved to `/home`
- `WelcomeBack.tsx`: new page, same Onboarding design language (TypingHero, THEMES), connects WS immediately, shows blinking cursor while opener loads
- `useUserProfile.ts`: fetches `name` + `onboarding_completed_at` from `profiles` table
- `useWelcomeBackSession.ts`: mirrors `useOnboardingSession`, connects to `/welcome-back-session/{id}`
- `Onboarding.tsx`: exports `TypingHero` and utilities for reuse; resume mode via `?resume=1`
- In-app `navigate('/')` → `navigate('/home')` across `SettingsPage`, `LessonPage`, `AuthLayout`

**Backend**
- `agent/welcome_back/`: new agent with `fire_opener=True`, greets by name+motivation, responds once, calls `complete_welcome_back()` to signal the frontend
- `agent/onboarding/tools/record_profile_tool.py`: new `record_profile(name, motivation)` tool — called by the onboarding agent as soon as it has both pieces; writes to `profiles` table early so data survives a dropped session
- `generate_lessons`: kept clean (no profile concerns); `_write_profile` reads from `collected` which `record_profile` populates
- `harness/context.py`: `WelcomeBackState`, `user_motivation` field on `UserInfo`
- `harness/session_manager.py`: fetches `name` + `motivation` from `profiles` on session creation so agents have real user context
- `channels/chat/routes.py`: `/welcome-back-session/{id}` WebSocket endpoint

## Bug fixed

`generate_lessons._write_profile` was always writing `name=null` because `collected["name"]` was never populated during the conversation (no tool existed to store it). The new `record_profile` tool fixes this — the agent now calls it explicitly once it has the learner's name and motivation.

## Test plan

- [ ] New user: clear localStorage + use a fresh anon account → opens `/` → redirected to `/onboarding` → complete flow → picks a lesson
- [ ] Returning user: log in as `pro@mishmish.io`, clear `wb-last-seen` from localStorage → opens `/` → redirected to `/welcome-back` → see LLM-generated greeting (varies each visit) → respond → navigate to `/home`
- [ ] Same-day revisit: after seeing welcome-back, navigate to `/` again → goes straight to `/home`
- [ ] Incomplete onboarding: user with `name` set but no `onboarding_completed_at` → `/onboarding?resume=1` with name-aware opening bubbles
- [ ] In-app navigation: from `/lesson/:id` or `/settings`, click back → lands on `/home`, not re-routed

🤖 Generated with [Claude Code](https://claude.com/claude-code)