### PR TITLE
feat(lesson): agent initiates lesson session with topic intro

### DIFF
--- a/web-api/agent/tutor/tutor_agent_hooks.py
+++ b/web-api/agent/tutor/tutor_agent_hooks.py
@@ -112,7 +112,7 @@ class TutorAgentHooks(AgentHooks):
         self.event_counter += 1
         print(
             f"[Tutor Assistant] Agent '{agent.name}' completed "
-            f"with output length {len(output)} chars (event #{self.event_counter})"
+            f"with output length {len(str(output))} chars (event #{self.event_counter})"
         )
 
         if context.context:

--- a/web-api/agent/tutor/tutor_instructions.py
+++ b/web-api/agent/tutor/tutor_instructions.py
@@ -49,8 +49,18 @@ def get_instructions(
 
     user_context = "\n".join(user_info_lines) if user_info_lines else "- No user information available"
 
+    lesson_section = ""
+    if app_context and app_context.lesson and app_context.lesson.lesson_id:
+        lesson_section = f"""
+
+## Current Lesson
+- title: {app_context.lesson.lesson_title}
+- objective: {app_context.lesson.lesson_objective}
+
+Open this session by introducing the lesson topic warmly and concisely, then start teaching immediately."""
+
     return f"""{instructions}
 
 ## User Info
-{user_context}
+{user_context}{lesson_section}
 """

--- a/web-api/harness/context.py
+++ b/web-api/harness/context.py
@@ -44,6 +44,13 @@ class WelcomeBackState(BaseModel):
     completed: bool = False
 
 
+class LessonState(BaseModel):
+    """State for a lesson session."""
+    lesson_id: Optional[str] = None
+    lesson_title: Optional[str] = None
+    lesson_objective: Optional[str] = None
+
+
 class AppContext(BaseModel):
     """
     Application context that tracks state throughout agent execution.
@@ -65,6 +72,9 @@ class AppContext(BaseModel):
 
     # Welcome-back state (only used for welcome-back sessions)
     welcome_back: WelcomeBackState = Field(default_factory=WelcomeBackState)
+
+    # Lesson state (only used for lesson sessions)
+    lesson: LessonState = Field(default_factory=LessonState)
 
     # Timestamp
     updated_at: datetime = Field(default_factory=datetime.now)
@@ -194,7 +204,10 @@ def create_context(
     user_id: Optional[str] = None,
     user_name: Optional[str] = None,
     user_motivation: Optional[str] = None,
-    active_tool: Optional[str] = None
+    active_tool: Optional[str] = None,
+    lesson_id: Optional[str] = None,
+    lesson_title: Optional[str] = None,
+    lesson_objective: Optional[str] = None,
 ) -> AppContext:
     """
     Create a new AppContext instance and store it indexed by session_id.
@@ -218,7 +231,12 @@ def create_context(
     context = AppContext(
         session_id=session_id,
         user=user_info,
-        agent=agent_state
+        agent=agent_state,
+        lesson=LessonState(
+            lesson_id=lesson_id,
+            lesson_title=lesson_title,
+            lesson_objective=lesson_objective,
+        ),
     )
 
     # Store context indexed by session_id

--- a/web-api/harness/runner.py
+++ b/web-api/harness/runner.py
@@ -33,7 +33,12 @@ async def generate_agent_response(session_id: str, user_message: str, user_acces
     # Run the agent
     result = await Runner.run(agent, user_message, session=session, context=context)
 
-    return result.final_output
+    output = result.final_output
+    if hasattr(output, "messages"):
+        from harness.response import TextMessage
+        parts = [msg.content.text for msg in output.messages if isinstance(msg, TextMessage)]
+        return " ".join(parts)
+    return str(output)
 
 
 async def generate_greeting(session_id: str, user_access_token: str | None = None) -> str:

--- a/web-api/harness/session_manager.py
+++ b/web-api/harness/session_manager.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional
 from harness.session import AgentSession
 from harness.context import create_context, delete_context
 from services.supabase_client import get_supabase_user_client, get_supabase_admin_client
-from services import posthog_service
+from services import posthog_service, lesson_service
 
 
 class AuthenticationError(Exception):
@@ -18,7 +18,7 @@ class AuthenticationError(Exception):
 _sessions: Dict[str, AgentSession] = {}
 
 
-def create_session(user_access_token: str) -> str:
+def create_session(user_access_token: str, lesson_id: Optional[str] = None) -> str:
     """
     Create a new agent session and store it.
     Also creates an associated context for the session.
@@ -59,12 +59,27 @@ def create_session(user_access_token: str) -> str:
         profile_name = None
         profile_motivation = None
 
+    # Resolve lesson data if provided
+    lesson_title = None
+    lesson_objective = None
+    if lesson_id:
+        try:
+            lesson_data = lesson_service.get_lesson(lesson_id)
+            if lesson_data:
+                lesson_title = lesson_data.get("title")
+                lesson_objective = lesson_data.get("objective")
+        except Exception:
+            pass
+
     # Create context for this session
     create_context(
         session_id=session_id,
         user_id=actual_user_id,
         user_name=profile_name,
         user_motivation=profile_motivation,
+        lesson_id=lesson_id,
+        lesson_title=lesson_title,
+        lesson_objective=lesson_objective,
     )
 
     # Track session creation

--- a/web-api/routes/session.py
+++ b/web-api/routes/session.py
@@ -6,8 +6,10 @@ import time
 from fastapi import APIRouter, HTTPException, UploadFile, File, Depends
 from pydantic import BaseModel, Field
 
+from agent.tutor import tutor_agent as tutor_module
 from channels.chat import connection_manager as websocket_service
 from harness import session_manager as session_service, runner as agent_service, context as context_service, scaffolding as scaffolding_service
+from harness.turn import run_turn
 from services import posthog_service, soniox_service, transcript_service, plan_service
 from dependencies.auth import get_current_user, get_current_user_token
 
@@ -77,7 +79,7 @@ router = APIRouter(prefix="/sessions", tags=["Session"])
 
 
 @router.post("", response_model=SessionResponse)
-async def create_session(access_token: str = Depends(get_current_user_token)):
+async def create_session(lesson_id: str | None = None, access_token: str = Depends(get_current_user_token)):
     """
     Generate a new session ID.
 
@@ -94,7 +96,7 @@ async def create_session(access_token: str = Depends(get_current_user_token)):
         HTTPException: 401 if authentication fails, 500 if session creation fails
     """
     try:
-        session_id = session_service.create_session(access_token)
+        session_id = session_service.create_session(access_token, lesson_id=lesson_id)
     except session_service.AuthenticationError as e:
         raise HTTPException(status_code=401, detail=str(e))
     except Exception as e:
@@ -123,6 +125,32 @@ async def list_user_sessions(access_token: str = Depends(get_current_user_token)
     except session_service.AuthenticationError as e:
         raise HTTPException(status_code=401, detail=str(e))
     return SessionListResponse(sessions=sessions)
+
+
+@router.post("/{session_id}/opener", response_model=TextResponse)
+async def fire_opener(
+    session_id: str,
+    access_token: str = Depends(get_current_user_token),
+):
+    """Generate the agent's opening message for a session without user input."""
+    session = session_service.get_session(session_id, user_access_token=access_token)
+    if not session:
+        raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found")
+
+    try:
+        result = await run_turn(
+            session_id,
+            user_message=None,
+            agent=tutor_module.agent,
+            config=tutor_module.harness_options.turn_config(),
+        )
+    except Exception as e:
+        import traceback
+        logger.error(f"[Opener] run_turn failed for session {session_id}: {e}")
+        logger.error(traceback.format_exc())
+        raise HTTPException(status_code=500, detail=f"Opener failed: {str(e)}")
+
+    return TextResponse(text=result.display_text, highlights=[])
 
 
 @router.post("/{session_id}/chat", response_model=TextResponse)

--- a/web-app/src/api/sessions/sessions.api.ts
+++ b/web-app/src/api/sessions/sessions.api.ts
@@ -37,8 +37,9 @@ export async function getSessions(): Promise<Session[]> {
  *
  * Backend endpoint: POST /sessions
  */
-export async function createSession(): Promise<string> {
-  const response = await apiClient.post<CreateSessionResponse>('/sessions');
+export async function createSession(lessonId?: string): Promise<string> {
+  const params = lessonId ? { lesson_id: lessonId } : undefined;
+  const response = await apiClient.post<CreateSessionResponse>('/sessions', undefined, { params });
   return response.data.session_id;
 }
 
@@ -53,6 +54,18 @@ export async function createSession(): Promise<string> {
  *
  * Backend endpoint: POST /sessions/{session_id}/chat
  */
+/**
+ * Fire the agent's opening message for a session (no user input required).
+ *
+ * Backend endpoint: POST /sessions/{session_id}/opener
+ */
+export async function fireOpener(sessionId: string): Promise<string> {
+  const response = await apiClient.post<SendMessageResponse>(
+    `/sessions/${sessionId}/opener`,
+  );
+  return response.data.text;
+}
+
 export async function sendMessage(
   sessionId: string,
   message: string,

--- a/web-app/src/pages/LessonPage.tsx
+++ b/web-app/src/pages/LessonPage.tsx
@@ -1,13 +1,11 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Flex, Spinner, Text } from '@chakra-ui/react';
 import { ChatView } from '../components/ChatView/ChatView';
 import { useStore } from '../store';
 import { THEMES, FONT_STACK, TopBar } from '@/pages/Landing';
 import { useTranscriptMessages } from '@/hooks/useTranscriptMessages';
-import { getLesson, type LessonData } from '@/api/lessons';
-import { createSession } from '@/api/sessions/sessions.api';
-import type { TranscriptMessage } from '@/api/sessions/sessions.types';
+import { createSession, fireOpener } from '@/api/sessions/sessions.api';
 
 const theme = THEMES['apricot'];
 
@@ -23,7 +21,6 @@ function LessonPage() {
     return () => window.removeEventListener('resize', onResize);
   }, []);
 
-  const [lesson, setLesson] = useState<LessonData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const setActiveSessionId = useStore((s) => s.session.setActiveSessionId);
@@ -43,16 +40,16 @@ function LessonPage() {
 
     async function init() {
       try {
-        const [lessonData, sessionId] = await Promise.all([
-          getLesson(lessonId!),
-          createSession(),
-        ]);
+        const sessionId = await createSession(lessonId!);
         if (cancelled) return;
-        setLesson(lessonData);
+        await fireOpener(sessionId);
+        if (cancelled) return;
         setMessages([]);
         setActiveSessionId(sessionId);
-      } catch {
-        if (!cancelled) setError('Failed to load lesson. Please try again.');
+      } catch (err: unknown) {
+        const msg = (err as { response?: { data?: { detail?: string } }; message?: string })?.response?.data?.detail ?? (err as { message?: string })?.message ?? 'Unknown error';
+        console.error('[LessonPage] init failed:', err);
+        if (!cancelled) setError(`Failed to load lesson: ${msg}`);
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -62,26 +59,6 @@ function LessonPage() {
     return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lessonId]);
-
-  // Synthetic first "agent" message showing the lesson summary
-  const lessonIntroMessage = useMemo<TranscriptMessage | null>(() => {
-    if (!lesson || !activeSessionId) return null;
-    return {
-      message_id: `lesson:${lesson.id}:intro`,
-      session_id: activeSessionId,
-      user_id: '',
-      message_source: 'tutor',
-      message_kind: 'text',
-      message_text: `**${lesson.title}**\n\n${lesson.objective}`,
-      created_at: new Date(0).toISOString(),
-      updated_at: new Date(0).toISOString(),
-    };
-  }, [lesson, activeSessionId]);
-
-  const allMessages = useMemo(
-    () => (lessonIntroMessage ? [lessonIntroMessage, ...messages] : messages),
-    [lessonIntroMessage, messages],
-  );
 
   const pageStyle: React.CSSProperties = {
     background: theme.bg,
@@ -129,7 +106,7 @@ function LessonPage() {
             <Spinner size="xl" color={theme.tint} />
           </Flex>
         ) : (
-          <ChatView messages={allMessages} onStartCall={() => {}} theme={theme} />
+          <ChatView messages={messages} onStartCall={() => {}} theme={theme} />
         )}
       </Flex>
     </div>


### PR DESCRIPTION
## Summary

- When a user opens `/lesson/{lessonId}`, the tutor agent now fires an opening message introducing the lesson topic before any user input
- Lesson `title` and `objective` are passed to `POST /sessions` at session creation time, fetched from the DB, and stored in a new `LessonState` in `AppContext`
- New `POST /sessions/{id}/opener` endpoint runs the tutor via `run_turn` (same path the WebSocket uses for `fire_opener`) with no user message — the lesson context in the instructions guides the agent to intro the topic
- `LessonPage` awaits the opener before setting `activeSessionId`, so ChatView renders with the first message already present
- Removed the old client-side synthetic lesson intro bubble (agent now owns it)

**Bug fixes uncovered along the way:**
- `TutorAgentHooks.on_end` crashed with `TypeError: object of type 'AgentResponse' has no len()` — fixed with `str(output)`
- `runner.generate_agent_response` was returning the raw `AgentResponse` object instead of extracting canonical text, silently breaking REST chat message persistence — fixed by extracting `TextMessage` content

## Test plan

- [ ] Open a lesson from the home/onboarding flow — spinner shows while opener generates, then chat renders with the agent's lesson intro already visible
- [ ] Verify the intro references the correct lesson title/objective
- [ ] Send a text reply — chat continues normally
- [ ] Open a second lesson — a fresh session and opener are created for the new lesson

🤖 Generated with [Claude Code](https://claude.com/claude-code)