### PR TITLE
fix(web-app): audio bubble invisible on light theme and silent playback failure

### DIFF
--- a/web-app/src/components/Transcript/AudioBubble.tsx
+++ b/web-app/src/components/Transcript/AudioBubble.tsx
@@ -8,21 +8,32 @@ interface AudioBubbleProps {
   label?: string;
   /** Text direction for the label ('rtl' for Arabic script). */
   dir?: 'rtl' | 'ltr';
+  /** Set false when rendered on a light background. Defaults to true (dark background). */
+  isDark?: boolean;
 }
 
-export function AudioBubble({ audioUrl, label, dir }: AudioBubbleProps) {
+export function AudioBubble({ audioUrl, label, dir, isDark = true }: AudioBubbleProps) {
   const audioRef = useRef<HTMLAudioElement>(null);
   const [isPlaying, setIsPlaying] = useState(false);
 
-  const togglePlay = () => {
+  const togglePlay = async () => {
     if (!audioRef.current) return;
     if (isPlaying) {
       audioRef.current.pause();
     } else {
-      audioRef.current.play();
+      try {
+        await audioRef.current.play();
+        setIsPlaying(true);
+      } catch (err) {
+        console.error('[AudioBubble] playback failed:', err);
+      }
     }
-    setIsPlaying(!isPlaying);
   };
+
+  const fg = isDark ? 'white' : 'gray.800';
+  const fgMuted = isDark ? 'white/70' : 'gray.500';
+  const buttonBg = isDark ? 'white/20' : 'blackAlpha.100';
+  const buttonHoverBg = isDark ? 'white/30' : 'blackAlpha.200';
 
   return (
     <Flex align="center" gap={3}>
@@ -37,15 +48,15 @@ export function AudioBubble({ audioUrl, label, dir }: AudioBubbleProps) {
         onClick={togglePlay}
         rounded="full"
         size="sm"
-        bg="white/20"
-        color="white"
-        _hover={{ bg: 'white/30' }}
+        bg={buttonBg}
+        color={fg}
+        _hover={{ bg: buttonHoverBg }}
         variant="ghost"
       >
         {isPlaying ? <BsPauseFill /> : <BsPlayFill />}
       </IconButton>
       {label && (
-        <Text fontSize="sm" color="white/70" dir={dir}>
+        <Text fontSize="sm" color={fgMuted} dir={dir}>
           {label}
         </Text>
       )}

--- a/web-app/src/components/Transcript/Transcript.tsx
+++ b/web-app/src/components/Transcript/Transcript.tsx
@@ -113,6 +113,7 @@ function TranscriptBubble({ message, isFirstInGroup, responseMode, theme }: Tran
                 : message.message_text_transliterated ?? message.message_text_canonical ?? undefined
             }
             dir={responseMode === 'canonical' ? 'rtl' : undefined}
+            isDark={!theme}
           />
         ) : isUser ? (
           <Text fontSize="lg" lineHeight="relaxed">


### PR DESCRIPTION
## Summary

- **Visibility**: `AudioBubble` hardcoded `color="white"` and `bg="white/20"`, rendering the play button and label invisible on the lesson page's apricot (white) theme. Added an `isDark` prop (default `true`) and pass `isDark={!theme}` from `Transcript` so light-theme bubbles use dark gray controls.
- **Playback**: `play()` was not awaited — `setIsPlaying(true)` fired synchronously regardless of whether playback actually started. Now `togglePlay` is `async`, awaits `play()`, and only updates state on success. Rejections are logged to the console for easier debugging.

## Test plan

- [ ] Trigger an agent audio message in the lesson page — play button should be visible (dark icon on white bubble)
- [ ] Click play — audio should be audible; button should toggle to pause icon
- [ ] Click pause — audio stops, button reverts to play icon
- [ ] Audio message in the main chat (dark theme) — white controls still render correctly
- [ ] If playback fails, check console for `[AudioBubble] playback failed:` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)